### PR TITLE
Consolidate CI workflow & publish Kustomize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,50 +11,23 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
-    name: Build Docker Image
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.image-meta.outputs.tags }}
-      digest: ${{ steps.build.outputs.digest }}
+  publish-container-image:
     permissions:
+      id-token: write
       contents: read
       packages: write
-    steps:
-      - name: Clone the code
-        uses: actions/checkout@v4
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.0
+    with:
+      image-name: auth-provider-zitadel
+    secrets: inherit
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: image-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=pr
-            type=ref,event=branch
-            type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
-
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.image-meta.outputs.tags }}
-          labels: ${{ steps.image-meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  publish-kustomize-bundles:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.0
+    with:
+      bundle-name: ghcr.io/datum-cloud/auth-provider-zitadel-kustomize
+      bundle-path: config
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   publish-container-image:
     permissions:


### PR DESCRIPTION
This PR streamlines our GitHub Actions pipeline by:

1. Switching the Docker-image job to the reusable `datum-cloud/actions/.github/workflows/publish-docker.yaml` workflow
2. Adding a dedicated `publish-kustomize-bundles` job that builds and pushes the `auth-provider-zitadel-kustomize` bundle to GHCR.