### PR TITLE
Restructure to support sub-commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.0
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.1
     with:
       image-name: auth-provider-zitadel
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.0
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.1
     with:
       bundle-name: ghcr.io/datum-cloud/auth-provider-zitadel-kustomize
       bundle-path: config

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     -X 'go.miloapis.com/auth-provider-zitadel/pkg/version.Version=${VERSION}' \
     -X 'go.miloapis.com/auth-provider-zitadel/pkg/version.GitCommit=${GIT_COMMIT}' \
     -X 'go.miloapis.com/auth-provider-zitadel/pkg/version.BuildDate=${BUILD_DATE}'" \
-    -o manager cmd/main.go
+    -o auth-provider-zitadel cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/auth-provider-zitadel .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/auth-provider-zitadel"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,13 @@ FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+# Build arguments for version information
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -12,14 +18,21 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY cmd/main.go cmd/main.go
+COPY cmd/ cmd/
+COPY internal/ internal/
+COPY pkg/ pkg/
 
-# Build
+# Build with version information injected via ldflags
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a -ldflags="-w -s \
+    -X 'go.miloapis.com/auth-provider-zitadel/pkg/version.Version=${VERSION}' \
+    -X 'go.miloapis.com/auth-provider-zitadel/pkg/version.GitCommit=${GIT_COMMIT}' \
+    -X 'go.miloapis.com/auth-provider-zitadel/pkg/version.BuildDate=${BUILD_DATE}'" \
+    -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -1,0 +1,210 @@
+package controller
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"go.miloapis.com/auth-provider-zitadel/internal/config"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	// +kubebuilder:scaffold:scheme
+}
+
+// NewControllerCommand creates the controller subcommand
+func NewControllerCommand(globalConfig *config.GlobalConfig) *cobra.Command {
+	cfg := config.NewControllerConfig()
+
+	cmd := &cobra.Command{
+		Use:   "controller",
+		Short: "Run the Kubernetes controller manager",
+		Long: `Run the Kubernetes controller manager that watches for custom resources
+and manages the auth provider lifecycle.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runController(cfg, globalConfig)
+		},
+	}
+
+	// Controller-specific flags
+	cmd.Flags().StringVar(&cfg.MetricsAddr, "metrics-bind-address", cfg.MetricsAddr,
+		"The address the metrics endpoint binds to. Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	cmd.Flags().StringVar(&cfg.ProbeAddr, "health-probe-bind-address", cfg.ProbeAddr,
+		"The address the probe endpoint binds to.")
+	cmd.Flags().BoolVar(&cfg.EnableLeaderElection, "leader-elect", cfg.EnableLeaderElection,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	cmd.Flags().BoolVar(&cfg.SecureMetrics, "metrics-secure", cfg.SecureMetrics,
+		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+	cmd.Flags().BoolVar(&cfg.EnableHTTP2, "enable-http2", cfg.EnableHTTP2,
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+
+	// Certificate flags
+	cmd.Flags().StringVar(&cfg.Webhook.CertPath, "webhook-cert-path", cfg.Webhook.CertPath,
+		"The directory that contains the webhook certificate.")
+	cmd.Flags().StringVar(&cfg.Webhook.CertName, "webhook-cert-name", cfg.Webhook.CertName,
+		"The name of the webhook certificate file.")
+	cmd.Flags().StringVar(&cfg.Webhook.CertKey, "webhook-cert-key", cfg.Webhook.CertKey,
+		"The name of the webhook key file.")
+	cmd.Flags().StringVar(&cfg.Metrics.CertPath, "metrics-cert-path", cfg.Metrics.CertPath,
+		"The directory that contains the metrics server certificate.")
+	cmd.Flags().StringVar(&cfg.Metrics.CertName, "metrics-cert-name", cfg.Metrics.CertName,
+		"The name of the metrics server certificate file.")
+	cmd.Flags().StringVar(&cfg.Metrics.CertKey, "metrics-cert-key", cfg.Metrics.CertKey,
+		"The name of the metrics server key file.")
+
+	return cmd
+}
+
+func runController(cfg *config.ControllerConfig, globalConfig *config.GlobalConfig) error {
+	setupLog := ctrl.Log.WithName("setup")
+	setupLog.Info("Starting controller manager")
+
+	// Get TLS options
+	tlsOpts := cfg.GetTLSOptions()
+	if !cfg.EnableHTTP2 {
+		setupLog.Info("disabling http/2")
+	}
+
+	// Create watchers for metrics and webhooks certificates
+	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
+
+	// Setup webhook certificate watcher
+	if len(cfg.Webhook.CertPath) > 0 {
+		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
+			"webhook-cert-path", cfg.Webhook.CertPath, "webhook-cert-name", cfg.Webhook.CertName, "webhook-cert-key", cfg.Webhook.CertKey)
+
+		var err error
+		webhookCertWatcher, err = certwatcher.New(
+			filepath.Join(cfg.Webhook.CertPath, cfg.Webhook.CertName),
+			filepath.Join(cfg.Webhook.CertPath, cfg.Webhook.CertKey),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize webhook certificate watcher: %w", err)
+		}
+	}
+
+	// Initial webhook TLS options
+	webhookTLSOpts := tlsOpts
+	if webhookCertWatcher != nil {
+		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
+			config.GetCertificate = webhookCertWatcher.GetCertificate
+		})
+	}
+
+	webhookServer := webhook.NewServer(webhook.Options{
+		TLSOpts: webhookTLSOpts,
+	})
+
+	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
+	// More info:
+	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/server
+	// - https://book.kubebuilder.io/reference/metrics.html
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   cfg.MetricsAddr,
+		SecureServing: cfg.SecureMetrics,
+		TLSOpts:       tlsOpts,
+	}
+
+	if cfg.SecureMetrics {
+		// FilterProvider is used to protect the metrics endpoint with authn/authz.
+		// These configurations ensure that only authorized users and service accounts
+		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
+		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/filters#WithAuthenticationAndAuthorization
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+
+	// If the certificate is not specified, controller-runtime will automatically
+	// generate self-signed certificates for the metrics server. While convenient for development and testing,
+	// this setup is not recommended for production.
+	//
+	// TODO(user): If you enable certManager, uncomment the following lines:
+	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
+	// managed by cert-manager for the metrics server.
+	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
+	if len(cfg.Metrics.CertPath) > 0 {
+		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
+			"metrics-cert-path", cfg.Metrics.CertPath, "metrics-cert-name", cfg.Metrics.CertName, "metrics-cert-key", cfg.Metrics.CertKey)
+
+		var err error
+		metricsCertWatcher, err = certwatcher.New(
+			filepath.Join(cfg.Metrics.CertPath, cfg.Metrics.CertName),
+			filepath.Join(cfg.Metrics.CertPath, cfg.Metrics.CertKey),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize metrics certificate watcher: %w", err)
+		}
+
+		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
+			config.GetCertificate = metricsCertWatcher.GetCertificate
+		})
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsServerOptions,
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: cfg.ProbeAddr,
+		LeaderElection:         cfg.EnableLeaderElection,
+		LeaderElectionID:       cfg.LeaderElectionID,
+		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
+		// when the Manager ends. This requires the binary to immediately end when the
+		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+		// speeds up voluntary leader transitions as the new leader don't have to wait
+		// LeaseDuration time first.
+		//
+		// In the default scaffold provided, the program ends immediately after
+		// the manager stops, so would be fine to enable this option. However,
+		// if you are doing or is intended to do any operation such as perform cleanups
+		// after the manager stops then its usage might be unsafe.
+		// LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to start manager: %w", err)
+	}
+
+	// +kubebuilder:scaffold:builder
+
+	if metricsCertWatcher != nil {
+		setupLog.Info("Adding metrics certificate watcher to manager")
+		if err := mgr.Add(metricsCertWatcher); err != nil {
+			return fmt.Errorf("unable to add metrics certificate watcher to manager: %w", err)
+		}
+	}
+
+	if webhookCertWatcher != nil {
+		setupLog.Info("Adding webhook certificate watcher to manager")
+		if err := mgr.Add(webhookCertWatcher); err != nil {
+			return fmt.Errorf("unable to add webhook certificate watcher to manager: %w", err)
+		}
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up ready check: %w", err)
+	}
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		return fmt.Errorf("problem running manager: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,233 +1,57 @@
-/*
-Copyright 2025.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package main
 
 import (
-	"crypto/tls"
-	"flag"
+	"fmt"
 	"os"
-	"path/filepath"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	// +kubebuilder:scaffold:imports
+	"github.com/spf13/cobra"
+	"go.miloapis.com/auth-provider-zitadel/cmd/controller"
+	"go.miloapis.com/auth-provider-zitadel/cmd/version"
+	"go.miloapis.com/auth-provider-zitadel/internal/config"
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	globalConfig = &config.GlobalConfig{}
 )
 
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "auth-provider-zitadel",
+	Short: "Kubernetes auth provider for Zitadel",
+	Long: `A Kubernetes operator that provides authentication and authorization
+capabilities using Zitadel as the identity provider.
 
-	// +kubebuilder:scaffold:scheme
+This tool can run in multiple modes:
+- controller: Run the Kubernetes controller manager
+- version: Print version information`,
 }
 
-// nolint:gocyclo
 func main() {
-	var metricsAddr string
-	var metricsCertPath, metricsCertName, metricsCertKey string
-	var webhookCertPath, webhookCertName, webhookCertKey string
-	var enableLeaderElection bool
-	var probeAddr string
-	var secureMetrics bool
-	var enableHTTP2 bool
-	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
-		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&secureMetrics, "metrics-secure", true,
-		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
-	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
-	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
-	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
-		"The directory that contains the metrics server certificate.")
-	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
-	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
-	flag.BoolVar(&enableHTTP2, "enable-http2", false,
-		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	// if the enable-http2 flag is false (the default), http/2 should be disabled
-	// due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	if !enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
-	}
-
-	// Create watchers for metrics and webhooks certificates
-	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
-
-	// Initial webhook TLS options
-	webhookTLSOpts := tlsOpts
-
-	if len(webhookCertPath) > 0 {
-		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
-			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
-
-		var err error
-		webhookCertWatcher, err = certwatcher.New(
-			filepath.Join(webhookCertPath, webhookCertName),
-			filepath.Join(webhookCertPath, webhookCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
-			os.Exit(1)
-		}
-
-		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
-			config.GetCertificate = webhookCertWatcher.GetCertificate
-		})
-	}
-
-	webhookServer := webhook.NewServer(webhook.Options{
-		TLSOpts: webhookTLSOpts,
-	})
-
-	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
-	// More info:
-	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/server
-	// - https://book.kubebuilder.io/reference/metrics.html
-	metricsServerOptions := metricsserver.Options{
-		BindAddress:   metricsAddr,
-		SecureServing: secureMetrics,
-		TLSOpts:       tlsOpts,
-	}
-
-	if secureMetrics {
-		// FilterProvider is used to protect the metrics endpoint with authn/authz.
-		// These configurations ensure that only authorized users and service accounts
-		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
-		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/filters#WithAuthenticationAndAuthorization
-		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
-	}
-
-	// If the certificate is not specified, controller-runtime will automatically
-	// generate self-signed certificates for the metrics server. While convenient for development and testing,
-	// this setup is not recommended for production.
-	//
-	// TODO(user): If you enable certManager, uncomment the following lines:
-	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
-	// managed by cert-manager for the metrics server.
-	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
-	if len(metricsCertPath) > 0 {
-		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
-			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
-
-		var err error
-		metricsCertWatcher, err = certwatcher.New(
-			filepath.Join(metricsCertPath, metricsCertName),
-			filepath.Join(metricsCertPath, metricsCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
-			os.Exit(1)
-		}
-
-		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
-			config.GetCertificate = metricsCertWatcher.GetCertificate
-		})
-	}
-
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsServerOptions,
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "28f116c3.my.domain",
-		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
-		// when the Manager ends. This requires the binary to immediately end when the
-		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
-		// speeds up voluntary leader transitions as the new leader don't have to wait
-		// LeaseDuration time first.
-		//
-		// In the default scaffold provided, the program ends immediately after
-		// the manager stops, so would be fine to enable this option. However,
-		// if you are doing or is intended to do any operation such as perform cleanups
-		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
-	})
-	if err != nil {
-		setupLog.Error(err, "unable to start manager")
+	if err := execute(); err != nil {
 		os.Exit(1)
 	}
+}
 
-	// +kubebuilder:scaffold:builder
+// execute adds all child commands to the root command and sets flags appropriately.
+func execute() error {
+	cobra.OnInitialize(initConfig)
 
-	if metricsCertWatcher != nil {
-		setupLog.Info("Adding metrics certificate watcher to manager")
-		if err := mgr.Add(metricsCertWatcher); err != nil {
-			setupLog.Error(err, "unable to add metrics certificate watcher to manager")
-			os.Exit(1)
-		}
-	}
+	// Global flags
+	rootCmd.PersistentFlags().BoolVar(&globalConfig.Development, "development", false, "Enable development mode")
+	rootCmd.PersistentFlags().StringVar(&globalConfig.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().StringVar(&globalConfig.LogFormat, "log-format", "json", "Log format (json, console)")
 
-	if webhookCertWatcher != nil {
-		setupLog.Info("Adding webhook certificate watcher to manager")
-		if err := mgr.Add(webhookCertWatcher); err != nil {
-			setupLog.Error(err, "unable to add webhook certificate watcher to manager")
-			os.Exit(1)
-		}
-	}
+	// Add subcommands
+	rootCmd.AddCommand(controller.NewControllerCommand(globalConfig))
+	rootCmd.AddCommand(version.NewVersionCommand())
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
+	return rootCmd.Execute()
+}
 
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
+// initConfig reads in config file and ENV variables if set
+func initConfig() {
+	if err := config.InitializeLogging(globalConfig); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing logging: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,46 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.miloapis.com/auth-provider-zitadel/pkg/version"
+)
+
+// NewVersionCommand creates the version subcommand
+func NewVersionCommand() *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Long:  "Print version information for auth-provider-zitadel",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion(output)
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format (text, json)")
+
+	return cmd
+}
+
+func runVersion(output string) error {
+	versionInfo := version.Get()
+
+	switch output {
+	case "json":
+		data, err := json.MarshalIndent(versionInfo, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal version info: %w", err)
+		}
+		fmt.Println(string(data))
+	case "text":
+		fmt.Println(versionInfo.String())
+	default:
+		return fmt.Errorf("unsupported output format: %s", output)
+	}
+
+	return nil
+}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,11 +60,61 @@ spec:
       containers:
       - args:
           - controller
-          - --leader-elect
-          - --health-probe-bind-address=:8081
+          # Leader election configuration
+          - --leader-elect=$(LEADER_ELECT)
+          - --leader-election-id=$(LEADER_ELECTION_ID)
+          - --leader-election-namespace=$(LEADER_ELECTION_NAMESPACE)
+          - --leader-election-resource-lock=$(LEADER_ELECTION_RESOURCE_LOCK)
+          - --leader-election-lease-duration=$(LEADER_ELECTION_LEASE_DURATION)
+          - --leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)
+          - --leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)
+          - --leader-election-release-on-cancel=$(LEADER_ELECTION_RELEASE_ON_CANCEL)
+          # Health and metrics configuration
+          - --health-probe-bind-address=$(HEALTH_PROBE_BIND_ADDRESS)
+          - --metrics-bind-address=$(METRICS_BIND_ADDRESS)
+          - --metrics-secure=$(METRICS_SECURE)
+          # Global configuration
+          - --log-level=$(LOG_LEVEL)
+          - --log-format=$(LOG_FORMAT)
         image: ghcr.io/datum-cloud/auth-provider-zitadel:latest
         name: controller-manager
-        ports: []
+        env:
+        # Leader election environment variables
+        - name: LEADER_ELECT
+          value: "true"
+        - name: LEADER_ELECTION_ID
+          value: "auth-provider-zitadel-leader"
+        - name: LEADER_ELECTION_NAMESPACE
+          value: ""  # Uses current namespace
+        - name: LEADER_ELECTION_RESOURCE_LOCK
+          value: "leases"
+        - name: LEADER_ELECTION_LEASE_DURATION
+          value: "15s"
+        - name: LEADER_ELECTION_RENEW_DEADLINE
+          value: "10s"
+        - name: LEADER_ELECTION_RETRY_PERIOD
+          value: "2s"
+        - name: LEADER_ELECTION_RELEASE_ON_CANCEL
+          value: "true"
+        # Health and metrics environment variables
+        - name: HEALTH_PROBE_BIND_ADDRESS
+          value: ":8081"
+        - name: METRICS_BIND_ADDRESS
+          value: ":8443"
+        - name: METRICS_SECURE
+          value: "true"
+        # Global configuration environment variables
+        - name: LOG_LEVEL
+          value: "info"
+        - name: LOG_FORMAT
+          value: "json"
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,13 +58,12 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
+          - controller
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: controller:latest
-        name: manager
+        image: ghcr.io/datum-cloud/auth-provider-zitadel:latest
+        name: controller-manager
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	github.com/spf13/cobra v1.8.1
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -50,7 +51,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"crypto/tls"
+)
+
+// GlobalConfig holds configuration that's shared across all commands
+type GlobalConfig struct {
+	Development bool
+	LogLevel    string
+	LogFormat   string
+}
+
+// MetricsConfig holds metrics server configuration
+type MetricsConfig struct {
+	BindAddress   string
+	SecureServing bool
+	CertPath      string
+	CertName      string
+	CertKey       string
+}
+
+// WebhookConfig holds webhook server configuration
+type WebhookConfig struct {
+	CertPath string
+	CertName string
+	CertKey  string
+}
+
+// ControllerConfig holds controller-specific configuration
+type ControllerConfig struct {
+	MetricsAddr          string
+	ProbeAddr            string
+	EnableLeaderElection bool
+	LeaderElectionID     string
+	SecureMetrics        bool
+	EnableHTTP2          bool
+
+	// Certificate configurations
+	Metrics MetricsConfig
+	Webhook WebhookConfig
+}
+
+// NewControllerConfig returns a ControllerConfig with sensible defaults
+func NewControllerConfig() *ControllerConfig {
+	return &ControllerConfig{
+		MetricsAddr:          "0",
+		ProbeAddr:            ":8081",
+		EnableLeaderElection: false,
+		LeaderElectionID:     "28f116c3.my.domain",
+		SecureMetrics:        true,
+		EnableHTTP2:          false,
+		Metrics: MetricsConfig{
+			CertName: "tls.crt",
+			CertKey:  "tls.key",
+		},
+		Webhook: WebhookConfig{
+			CertName: "tls.crt",
+			CertKey:  "tls.key",
+		},
+	}
+}
+
+// GetTLSOptions returns TLS configuration options based on HTTP2 settings
+func (c *ControllerConfig) GetTLSOptions() []func(*tls.Config) {
+	var tlsOpts []func(*tls.Config)
+
+	if !c.EnableHTTP2 {
+		// Disable HTTP/2 for security reasons
+		disableHTTP2 := func(config *tls.Config) {
+			config.NextProtos = []string{"http/1.1"}
+		}
+		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	return tlsOpts
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,24 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (
 	"crypto/tls"
+	"time"
 )
 
 // GlobalConfig holds configuration that's shared across all commands
@@ -27,14 +44,27 @@ type WebhookConfig struct {
 	CertKey  string
 }
 
+// LeaderElectionConfig holds leader election configuration
+type LeaderElectionConfig struct {
+	Enabled         bool
+	ID              string
+	Namespace       string
+	ResourceLock    string
+	LeaseDuration   time.Duration
+	RenewDeadline   time.Duration
+	RetryPeriod     time.Duration
+	ReleaseOnCancel bool
+}
+
 // ControllerConfig holds controller-specific configuration
 type ControllerConfig struct {
-	MetricsAddr          string
-	ProbeAddr            string
-	EnableLeaderElection bool
-	LeaderElectionID     string
-	SecureMetrics        bool
-	EnableHTTP2          bool
+	MetricsAddr   string
+	ProbeAddr     string
+	SecureMetrics bool
+	EnableHTTP2   bool
+
+	// Leader election configuration
+	LeaderElection LeaderElectionConfig
 
 	// Certificate configurations
 	Metrics MetricsConfig
@@ -44,12 +74,20 @@ type ControllerConfig struct {
 // NewControllerConfig returns a ControllerConfig with sensible defaults
 func NewControllerConfig() *ControllerConfig {
 	return &ControllerConfig{
-		MetricsAddr:          "0",
-		ProbeAddr:            ":8081",
-		EnableLeaderElection: false,
-		LeaderElectionID:     "28f116c3.my.domain",
-		SecureMetrics:        true,
-		EnableHTTP2:          false,
+		MetricsAddr:   "0",
+		ProbeAddr:     ":8081",
+		SecureMetrics: true,
+		EnableHTTP2:   false,
+		LeaderElection: LeaderElectionConfig{
+			Enabled:         false,
+			ID:              "28f116c3.my.domain",
+			Namespace:       "",               // Use default namespace if empty
+			ResourceLock:    "leases",         // Default to leases
+			LeaseDuration:   15 * time.Second, // Default lease duration
+			RenewDeadline:   10 * time.Second, // Default renew deadline
+			RetryPeriod:     2 * time.Second,  // Default retry period
+			ReleaseOnCancel: false,            // Default to false for safety
+		},
 		Metrics: MetricsConfig{
 			CertName: "tls.crt",
 			CertKey:  "tls.key",

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// InitializeLogging sets up logging based on the global configuration
+func InitializeLogging(cfg *GlobalConfig) error {
+	opts := zap.Options{
+		Development: cfg.Development,
+	}
+
+	// Configure log format - console format enables development mode
+	if cfg.LogFormat == "console" {
+		opts.Development = true
+	}
+
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(logger)
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,41 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// These will be set by ldflags during build
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)
+
+// Info contains version information
+type Info struct {
+	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+	Compiler  string `json:"compiler"`
+	Platform  string `json:"platform"`
+}
+
+// Get returns version information
+func Get() Info {
+	return Info{
+		Version:   Version,
+		GitCommit: GitCommit,
+		BuildDate: BuildDate,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns a human-readable version string
+func (i Info) String() string {
+	return fmt.Sprintf("Version: %s\nGit Commit: %s\nBuild Date: %s\nGo Version: %s\nCompiler: %s\nPlatform: %s",
+		i.Version, i.GitCommit, i.BuildDate, i.GoVersion, i.Compiler, i.Platform)
+}


### PR DESCRIPTION
Moves the existing main command to a `controller` sub-command and a `version` command that can be used to determine what version of the binary is being used. 

Also introduced CLI arguments to support configuring leadership election for the controller. 