### PR TITLE
chore: fixes the metrics bind address patch

### DIFF
--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint using HTTPS
 - op: add
-  path: /spec/template/spec/containers/0/args/0
+  path: /spec/template/spec/containers/0/args/-
   value: --metrics-bind-address=:8443


### PR DESCRIPTION
The previous configuration is causing the zitadel auth provider to start because the `--metrics-bind-address` flag was being added before the `controller` command. This was a result of the patch adding the flag at index `0` in the container args. Changing it to `-` will append it to the end of the args list. 

### Before

```yaml
spec:
  containers:
  - args:
    - --metrics-bind-address=:8443
    - controller
    - --leader-elect=$(LEADER_ELECT)
    - --leader-election-id=$(LEADER_ELECTION_ID)
    - --leader-election-namespace=$(LEADER_ELECTION_NAMESPACE)
    - --leader-election-resource-lock=$(LEADER_ELECTION_RESOURCE_LOCK)
    - --leader-election-lease-duration=$(LEADER_ELECTION_LEASE_DURATION)
    - --leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)
    - --leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)
    - --leader-election-release-on-cancel=$(LEADER_ELECTION_RELEASE_ON_CANCEL)
    - --health-probe-bind-address=$(HEALTH_PROBE_BIND_ADDRESS)
    - --metrics-bind-address=$(METRICS_BIND_ADDRESS)
    - --metrics-secure=$(METRICS_SECURE)
    - --log-level=$(LOG_LEVEL)
    - --log-format=$(LOG_FORMAT)
    - --leader-election-namespace=milo-system
```

### After

```yaml
spec:
  containers:
  - args:
    - controller
    - --leader-elect=$(LEADER_ELECT)
    - --leader-election-id=$(LEADER_ELECTION_ID)
    - --leader-election-namespace=$(LEADER_ELECTION_NAMESPACE)
    - --leader-election-resource-lock=$(LEADER_ELECTION_RESOURCE_LOCK)
    - --leader-election-lease-duration=$(LEADER_ELECTION_LEASE_DURATION)
    - --leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)
    - --leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)
    - --leader-election-release-on-cancel=$(LEADER_ELECTION_RELEASE_ON_CANCEL)
    - --health-probe-bind-address=$(HEALTH_PROBE_BIND_ADDRESS)
    - --metrics-bind-address=$(METRICS_BIND_ADDRESS)
    - --metrics-secure=$(METRICS_SECURE)
    - --log-level=$(LOG_LEVEL)
    - --log-format=$(LOG_FORMAT)
    - --leader-election-namespace=milo-system
    - --metrics-bind-address=:8443
```