### PR TITLE
Add authentication webhook server and Kubernetes deployment for Zitadel integration

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -22,7 +22,7 @@ tasks:
       - generate-webhookserver-certs
     cmds:
       - |
-          go run cmd/main.go auth-webhook \
+          go run cmd/main.go authn-webhook \
             --webhook-port 8443 \
             --cert-dir "certs" \
             --cert-file "server.crt" \

--- a/cmd/webhookserver/command.go
+++ b/cmd/webhookserver/command.go
@@ -25,7 +25,7 @@ func NewAuthenticationWebhookServerCommand(globalConfig *config.GlobalConfig) *c
 	cfg := config.NewWebhookServerConfig()
 
 	cmd := &cobra.Command{
-		Use:   "auth-webhook",
+		Use:   "authn-webhook",
 		Short: "Runs the User Authentication TokenReview webhook server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWebhookServer(cmd, cfg)

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base application components for auth-provider-zitadel
+# This includes all core components needed for the application
+
+# Common namespace for all application resources
+namespace: auth-provider-zitadel-system
+
+# Common name prefix for all resources
+namePrefix: auth-provider-zitadel-
+
+resources:
+  - services/authn-webhook

--- a/config/base/services/authn-webhook/authn-webhook-service.yaml
+++ b/config/base/services/authn-webhook/authn-webhook-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: authn-webhook
+  labels:
+    app.kubernetes.io/name: authn-webhook
+    app.kubernetes.io/part-of: auth-provider-zitadel
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    app.kubernetes.io/name: authn-webhook
+    app.kubernetes.io/part-of: auth-provider-zitadel
+  ports:
+    - name: webhook-https
+      port: 8090
+      targetPort: 8090
+      protocol: TCP
+    - name: metrics
+      port: 8443
+      targetPort: 8443
+      protocol: TCP

--- a/config/base/services/authn-webhook/authn-webhook.yaml
+++ b/config/base/services/authn-webhook/authn-webhook.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authn-webhook
+  labels:
+    app.kubernetes.io/name: authn-webhook
+    app.kubernetes.io/part-of: auth-provider-zitadel
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authn-webhook
+      app.kubernetes.io/part-of: auth-provider-zitadel
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: authn-webhook
+        app.kubernetes.io/part-of: auth-provider-zitadel
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: authn-webhook
+          image: auth-provider-zitadel:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - authn-webhook
+            - --webhook-port=8090
+            - --cert-dir=certs
+            - --cert-file=tls.crt
+            - --key-file=tls.key
+            - --zitadel-domain=$(ZITADEL_DOMAIN)
+            - --jwt-expiration=1h
+            - --metrics-bind-address=:8443
+          env:
+            - name: ZITADEL_DOMAIN
+              value: https://auth.datum.net
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            - containerPort: 8090
+              name: webhook
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          volumeMounts: []
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes: []

--- a/config/base/services/authn-webhook/kustomization.yaml
+++ b/config/base/services/authn-webhook/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- authn-webhook.yaml
+- authn-webhook-service.yaml
+images:
+- name: auth-provider-zitadel
+  newName: auth-provider-zitadel
+  newTag: dev


### PR DESCRIPTION
This PR introduces a new authentication webhook server for Kubernetes, enabling integration with Zitadel as an external authentication provider. 