### PR TITLE
Support reconciling resources in core control plane

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,11 @@ type ControllerConfig struct {
 	ServerConfigFile          string
 	EmailAddressSuffix        string
 
+	// The kubeconfig file that is used to connect and authenticate with the core
+	// control plane to reconcile core Milo resources. Defaults to the in-cluster
+	// kubeconfig when an empty value is provided.
+	CoreControlPlaneKubeconfig string
+
 	// Zitadel connection details
 	Zitadel ZitadelConfig
 }
@@ -145,6 +150,14 @@ func (c *DownstreamResourceManagementConfig) RestConfig() (*rest.Config, error) 
 	}
 
 	return clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)
+}
+
+func (c *ControllerConfig) CoreControlPlaneRestConfig() (*rest.Config, error) {
+	if c.CoreControlPlaneKubeconfig == "" {
+		return ctrl.GetConfig()
+	}
+
+	return clientcmd.BuildConfigFromFlags("", c.CoreControlPlaneKubeconfig)
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
The core Milo control plane is used to manage users, organizations, and other platform-level resources. The multi-cluster runtime provider provided by Milo is only used to dynamically reconcile resources in project control planes. This PR updates the zitadel provider to add support for providing a new core control plane kubeconfig to configure how to connect to the core control plane. 

Additionally, the MachineAccount controller was updated to leverage the multi-cluster runtime manager to dynamically retrieve the client based on the cluster the resource being reconciled exists in.