### PR TITLE
feat: Support both self-registered and user-added user events in webhook handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ Follow these steps to run the end-to-end (e2e) tests locally:
    ```bash
    cat test/controller.log
    ```
+
+## Zitadel Instance Setup
+
+1. Create an Actions V2 target that points to the `create-user-webhook` endpoint:
+
+`https://localhost:8888/v1/actions/create-user-account`
+
+1. Create an Actions V2 action based on your UI type:
+   - **Zitadel UI**: Configure the event `user.human.selfregistered` with the previously created target
+   - **Zitadel Custom UI**: Configure the event `user.human.added` with the previously created target

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -54,18 +54,25 @@ func NewServer(cfg *ServerConfig, k8sClient client.Client, validateSignatureFunc
 	}
 }
 
+type EventType string
+
+const (
+	EventTypeUserHumanSelfRegistered EventType = "user.human.selfregistered"
+	EventTypeUserHumanAdded          EventType = "user.human.added"
+)
+
 // createUserAccountRequest represents the expected JSON payload for the endpoint.
 // It matches the structure provided by Zitadel actions.
 type createUserAccountRequest struct {
-	AggregateID   string `json:"aggregateID"`
-	AggregateType string `json:"aggregateType"`
-	ResourceOwner string `json:"resourceOwner"`
-	InstanceID    string `json:"instanceID"`
-	Version       string `json:"version"`
-	Sequence      int    `json:"sequence"`
-	EventType     string `json:"event_type"`
-	CreatedAt     string `json:"created_at"`
-	UserID        string `json:"userID"`
+	AggregateID   string    `json:"aggregateID"`
+	AggregateType string    `json:"aggregateType"`
+	ResourceOwner string    `json:"resourceOwner"`
+	InstanceID    string    `json:"instanceID"`
+	Version       string    `json:"version"`
+	Sequence      int       `json:"sequence"`
+	EventType     EventType `json:"event_type"`
+	CreatedAt     string    `json:"created_at"`
+	UserID        string    `json:"userID"`
 	EventPayload  struct {
 		UserName          string `json:"userName"`
 		FirstName         string `json:"firstName"`
@@ -142,9 +149,8 @@ func (s *Server) createUserAccountHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	log.V(1).Info("Request body unmarshaled successfully")
-
 	// Validate event type
-	if req.EventType != "user.human.selfregistered" {
+	if req.EventType != EventTypeUserHumanSelfRegistered && req.EventType != EventTypeUserHumanAdded {
 		log.Error(nil, "Unsupported event type", "eventType", req.EventType)
 		http.Error(w, fmt.Sprintf("unsupported event type: %s", req.EventType), http.StatusBadRequest)
 		return

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +61,8 @@ const (
 	EventTypeUserHumanSelfRegistered EventType = "user.human.selfregistered"
 	EventTypeUserHumanAdded          EventType = "user.human.added"
 )
+
+var SupportedUserCreationEvents = []EventType{EventTypeUserHumanSelfRegistered, EventTypeUserHumanAdded}
 
 // createUserAccountRequest represents the expected JSON payload for the endpoint.
 // It matches the structure provided by Zitadel actions.
@@ -150,7 +153,7 @@ func (s *Server) createUserAccountHandler(w http.ResponseWriter, r *http.Request
 	}
 	log.V(1).Info("Request body unmarshaled successfully")
 	// Validate event type
-	if req.EventType != EventTypeUserHumanSelfRegistered && req.EventType != EventTypeUserHumanAdded {
+	if !slices.Contains(SupportedUserCreationEvents, req.EventType) {
 		log.Error(nil, "Unsupported event type", "eventType", req.EventType)
 		http.Error(w, fmt.Sprintf("unsupported event type: %s", req.EventType), http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Description
This PR enhances the user creation webhook handler to properly support both user event types from Zitadel:
- `user.human.selfregistered`: When users self-register through Zitadel UI
- `user.human.added`: When users self-register through a custom self hosted Zitadel UI
