### PR TITLE
feat: add UserController for managing user lifecycle and finalization with Zitadel integration

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -416,6 +416,15 @@ func runController(cfg *config.ControllerConfig, globalConfig *config.GlobalConf
 		os.Exit(1)
 	}
 
+	// Setup UserController on core control plane manager
+	if err = (&controller.UserController{
+		Client:  coreControlPlaneMgr.GetClient(),
+		Zitadel: zitadelHtppClient,
+	}).SetupWithManager(coreControlPlaneMgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "User")
+		os.Exit(1)
+	}
+
 	// Add core control plane manager as a runnable that starts only when main manager is leader
 	if err := mgr.Add(&coreControlPlaneRunnable{
 		mgr:                 mgr,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
   - machineaccounts/finalizers
   - userdeactivations/finalizers
   - userdeactivations/status
+  - users/finalizers
   verbs:
   - update
 - apiGroups:
@@ -47,6 +48,10 @@ rules:
   - users
   verbs:
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - infrastructure.miloapis.com
   resources:

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -1,0 +1,113 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/finalizer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"go.miloapis.com/auth-provider-zitadel/internal/zitadel"
+)
+
+const (
+	userFinalizerKey = "iam.miloapis.com/user"
+)
+
+// UserController reconciles User objects to handle deletions and Zitadel cleanup.
+type UserController struct {
+	client.Client
+	Finalizers finalizer.Finalizers
+	Zitadel    *zitadel.Client
+}
+
+type userFinalizer struct {
+	Zitadel *zitadel.Client
+}
+
+// Finalize implements finalizer.Finalizer for User resources.
+func (f *userFinalizer) Finalize(ctx context.Context, obj client.Object) (finalizer.Result, error) {
+	log := logf.FromContext(ctx).WithName("user-finalizer")
+
+	user, ok := obj.(*iammiloapiscomv1alpha1.User)
+	if !ok {
+		err := fmt.Errorf("unexpected object type %T, expected User", obj)
+		log.Error(err, "Type assertion failed")
+		return finalizer.Result{}, err
+	}
+
+	log.Info("Finalizing User deletion", "userName", user.GetName(), "userUID", user.GetUID())
+
+	// Delete the user in Zitadel if it exists.
+	if err := f.Zitadel.DeleteUser(ctx, user.GetName()); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("User already deleted in Zitadel, skipping", "userName", user.GetName())
+		} else {
+			log.Error(err, "Failed to delete user in Zitadel", "userName", user.GetName())
+			return finalizer.Result{}, fmt.Errorf("failed to delete user in Zitadel: %w", err)
+		}
+	}
+
+	log.Info("Successfully deleted user", "userName", user.GetName())
+
+	return finalizer.Result{}, nil
+}
+
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=users,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=users/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=users/finalizers,verbs=update
+
+// Reconcile executes the reconciliation loop for User resources.
+func (r *UserController) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx).WithName("user-reconciler")
+	log.Info("Starting reconciliation", "request", req)
+
+	user := &iammiloapiscomv1alpha1.User{}
+	if err := r.Get(ctx, req.NamespacedName, user); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("User resource not found. Ignoring since object must be deleted.")
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Failed to get User resource")
+		return ctrl.Result{}, fmt.Errorf("failed to get User resource: %w", err)
+	}
+
+	// Run finalizers.
+	finalizeResult, err := r.Finalizers.Finalize(ctx, user)
+	if err != nil {
+		log.Error(err, "Failed to run finalizers for User")
+		return ctrl.Result{}, fmt.Errorf("failed to run finalizers for User: %w", err)
+	}
+	if finalizeResult.Updated {
+		log.Info("Finalizer updated the User object, updating API server")
+		if updateErr := r.Update(ctx, user); updateErr != nil {
+			log.Error(updateErr, "Failed to update User after finalizer update")
+			return ctrl.Result{}, fmt.Errorf("failed to update User after finalizer update: %w", updateErr)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciliation complete")
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the controller with the provided manager.
+func (r *UserController) SetupWithManager(mgr manager.Manager) error {
+	r.Finalizers = finalizer.NewFinalizers()
+	if err := r.Finalizers.Register(userFinalizerKey, &userFinalizer{
+		Zitadel: r.Zitadel,
+	}); err != nil {
+		return fmt.Errorf("failed to register user finalizer: %w", err)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&iammiloapiscomv1alpha1.User{}).
+		Named("user").
+		Complete(r)
+}

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -1,0 +1,134 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
+	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/finalizer"
+
+	"go.miloapis.com/auth-provider-zitadel/internal/zitadel"
+	"golang.org/x/oauth2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("UserController", func() {
+	var (
+		scheme    *runtime.Scheme
+		k8sClient client.Client
+		ctx       context.Context
+	)
+
+	ginkgo.BeforeEach(func() {
+		ctx = context.TODO()
+		scheme = runtime.NewScheme()
+		gomega.Expect(iammiloapiscomv1alpha1.AddToScheme(scheme)).To(gomega.Succeed())
+		k8sClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	})
+
+	ginkgo.Context("Reconcile", func() {
+		ginkgo.It("should ignore requests for missing User resources", func() {
+			r := &UserController{
+				Client:     k8sClient,
+				Finalizers: finalizer.NewFinalizers(),
+			}
+
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "ghost"}}
+			res, err := r.Reconcile(ctx, req)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(res.RequeueAfter).To(gomega.Equal(time.Duration(0)))
+		})
+	})
+
+	ginkgo.Context("userFinalizer", func() {
+		ginkgo.It("should skip deletion when user not found in Zitadel", func() {
+			var getCalls, deleteCalls int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					atomic.AddInt32(&getCalls, 1)
+					http.NotFound(w, r)
+					return
+				}
+				ginkgo.GinkgoT().Errorf("unexpected method %s", r.Method)
+			}))
+			defer ts.Close()
+
+			client := zitadel.NewClientWithTokenSource(ts.URL, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test", TokenType: "Bearer"}))
+			f := &userFinalizer{Zitadel: client}
+
+			user := &iammiloapiscomv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: "john"}}
+			res, err := f.Finalize(ctx, user)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(res.Updated).To(gomega.BeFalse())
+			gomega.Expect(getCalls).To(gomega.BeNumerically(">=", 1))
+			gomega.Expect(deleteCalls).To(gomega.BeZero())
+		})
+
+		ginkgo.It("should delete user when present in Zitadel", func() {
+			var deleteCalls int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"user": {"userId": "john"}, "details": {}}`))
+					return
+				}
+				if r.Method == http.MethodDelete {
+					atomic.AddInt32(&deleteCalls, 1)
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				ginkgo.GinkgoT().Errorf("unexpected method %s", r.Method)
+			}))
+			defer ts.Close()
+
+			client := zitadel.NewClientWithTokenSource(ts.URL, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test", TokenType: "Bearer"}))
+			f := &userFinalizer{Zitadel: client}
+			user := &iammiloapiscomv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: "john"}}
+
+			res, err := f.Finalize(ctx, user)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(res.Updated).To(gomega.BeFalse())
+			gomega.Expect(deleteCalls).To(gomega.Equal(int32(1)))
+		})
+	})
+
+	ginkgo.Context("Finalizer registration", func() {
+		ginkgo.It("should add the user finalizer on first reconcile", func() {
+			// Arrange: create a User without finalizers in the fake cluster
+			user := &iammiloapiscomv1alpha1.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "alice"},
+			}
+			gomega.Expect(k8sClient.Create(ctx, user)).To(gomega.Succeed())
+
+			// Setup controller with proper finalizer registration (no Zitadel interaction needed)
+			finalizers := finalizer.NewFinalizers()
+			gomega.Expect(finalizers.Register(userFinalizerKey, &userFinalizer{})).To(gomega.Succeed())
+
+			r := &UserController{
+				Client:     k8sClient,
+				Finalizers: finalizers,
+			}
+
+			// Act: reconcile the user
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "alice"}})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Assert: the user object now contains the finalizer key
+			updated := &iammiloapiscomv1alpha1.User{}
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alice"}, updated)).To(gomega.Succeed())
+			gomega.Expect(updated.GetFinalizers()).To(gomega.ContainElement(userFinalizerKey))
+		})
+	})
+})


### PR DESCRIPTION
### PR Title

Add minimal User controller with ZITADEL-cleanup finalizer + tests

### PR Description

#### Adds UserController that:
    
*   Registers iam.miloapis.com/user finalizer
    
*   Deletes the corresponding user in ZITADEL on CR deletion
    
#### Unit tests cover:
    
*   Finalizer added on first reconcile
    
*   Skip delete when user absent in ZITADEL
    
*   Delete call when user exists
    
*   Graceful reconcile for missing CRs
    
Closes https://github.com/datum-cloud/auth-provider-zitadel/issues/41
