### PR TITLE
Add IDP Intent Succeeded Handler with User Patch for Avatar and idpName Sync

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -31,7 +31,16 @@ tasks:
             --zitadel-domain "{{.ZITADEL_DOMAIN}}" \
             --jwt-expiration 1h \
             --metrics-bind-address :8081
-
-          
-
+            
+  run-actionsserver:
+    desc: Run the HTTP actions server locally
+    deps:
+      - generate-webhookserver-certs
+    cmds:
+      - |
+          go run cmd/main.go actions-server \
+            --addr :8443 \
+            --kubeconfig ~/.kube/config \
+            --disable-signature-validation=true
   
+

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/zitadel/oidc/v3 v3.44.0
 	github.com/zitadel/zitadel v1.80.0-v2.20.0.20250619094244-3a4298c1794a
 	github.com/zitadel/zitadel-go/v3 v3.13.0
-	go.miloapis.com/milo v0.6.1-0.20251022132600-85f370c87065
+	go.miloapis.com/milo v0.12.7-0.20251209175533-fd3c212adb82
 	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ go.etcd.io/etcd/server/v3 v3.5.21 h1:9w0/k12majtgarGmlMVuhwXRI2ob3/d1Ik3X5TKo0yU
 go.etcd.io/etcd/server/v3 v3.5.21/go.mod h1:G1mOzdwuzKT1VRL7SqRchli/qcFrtLBTAQ4lV20sXXo=
 go.miloapis.com/milo v0.6.1-0.20251022132600-85f370c87065 h1:DDVrMWHgH1tL9GUy05peVNPcropgxreRWVUAZDSR8ac=
 go.miloapis.com/milo v0.6.1-0.20251022132600-85f370c87065/go.mod h1:oqwtjt5zV+Q07TFADtq/dZGmqw/U67VS0Pq1H+97Gi8=
+go.miloapis.com/milo v0.12.7-0.20251209175533-fd3c212adb82 h1:kK3Jpba59+s0Zrwo4T5aXpm/GCO1vG/IPLYPR5ljebY=
+go.miloapis.com/milo v0.12.7-0.20251209175533-fd3c212adb82/go.mod h1:xOFYvUsvSZV3z6eow5YdB5C/qRQf2s/5/arcfJs5XPg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -389,7 +389,8 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 	current.Status.AvatarURL = avatarURL
 	current.Status.LastLoginProvider = idpProvider
 
-	if err := s.k8sClient.Status().Patch(ctx, current, client.MergeFrom(original)); err != nil {
+	fieldManagerName := "idp-intent-succeeded"
+	if err := s.k8sClient.Status().Patch(ctx, current, client.MergeFrom(original), client.FieldOwner(fieldManagerName)); err != nil {
 		log.Error(err, "Failed to patch User status")
 		http.Error(w, "failed to patch user", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
# IDP Intent Succeeded Handler

## PR Title
Add IDP Intent Succeeded Handler with User Patch for Avatar and idpProviderSync

## Description
This feature introduces a dedicated `/v1/actions/idp-intent-succeeded` HTTP handler for Zitadel Webhook events of type `idpintent.succeeded`. The handler:
- Extracts the avatar URL, IDP provider from Google or GitHub logins.
- Patches the respective `User` Kubernetes resource:
  - Updates status fields: `avatarURL`, `lastLoginProvider`

This enables automatic enrichment and synchronization of user profiles across systems after external authentication.

> [!NOTE]
>
> Requires the creation of Zitadel action v2 with target for the idpintent.succeeded event, with path `/v1/actions/idp-intent-succeeded`


Relates https://github.com/datum-cloud/enhancements/issues/489