### PR TITLE
feat: add kustomize bundle publishing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
     uses: datum-cloud/actions/.github/workflows/validate-kustomize.yaml@v1.9.0
 
   publish-container-image:
+    needs: validate-kustomize
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,16 @@ on:
     types: [published]
 
 jobs:
+
+  check-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+  validate-kustomize:
+    uses: datum-cloud/actions/.github/workflows/validate-kustomize.yaml@v1.9.0
+
   publish-container-image:
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,10 @@ on:
   push:
     paths-ignore:
       - "README.md"
-      - "env.example"
-      - ".vscode/**"
       
   pull_request:
     paths-ignore:
       - "README.md"
-      - "env.example"
-      - ".vscode/**"
 
   release:
     types: [published]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,19 @@ name: Build and Push Docker Image
 
 on:
   push:
+    paths-ignore:
+      - "README.md"
+      - "env.example"
+      - ".vscode/**"
+      
   pull_request:
+    paths-ignore:
+      - "README.md"
+      - "env.example"
+      - ".vscode/**"
+
+  release:
+    types: [published]
 
 jobs:
   publish-container-image:
@@ -10,18 +22,22 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
     with:
       image-name: auth-provider-zitadel
     secrets: inherit
 
   publish-kustomize-bundles:
+    needs: publish-container-image
     permissions:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.9.0
     with:
       bundle-name: ghcr.io/datum-cloud/auth-provider-zitadel-kustomize
       bundle-path: config
+      image-overlays: config/base
+      image-name: ghcr.io/datum-cloud/auth-provider-zitadel
+      debug: true
     secrets: inherit


### PR DESCRIPTION
Add publish-kustomize-bundles job to build workflow that publishes kustomize configurations as OCI artifacts to GHCR. This enables GitOps deployments to reference versioned kustomize bundles with automatic image tag injection for all auth-provider-zitadel services.