### PR TITLE
fix(apiserver): rename identityproviders to useridentities

### DIFF
--- a/cmd/apiserver/command.go
+++ b/cmd/apiserver/command.go
@@ -21,8 +21,8 @@ import (
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 
-	registryidentityproviders "go.miloapis.com/auth-provider-zitadel/internal/apiserver/identity/identityproviders"
 	registrysessions "go.miloapis.com/auth-provider-zitadel/internal/apiserver/identity/sessions"
+	registryuseridentities "go.miloapis.com/auth-provider-zitadel/internal/apiserver/identity/useridentities"
 	"go.miloapis.com/auth-provider-zitadel/internal/config"
 	identityinstall "go.miloapis.com/auth-provider-zitadel/pkg/apis/identity"
 	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
@@ -141,8 +141,8 @@ func NewAPIServerCommand(global *config.GlobalConfig) *cobra.Command {
 			}
 
 			storage := map[string]rest.Storage{
-				"sessions":          &registrysessions.REST{Z: zc},
-				"identityproviders": &registryidentityproviders.REST{Z: zc},
+				"sessions":       &registrysessions.REST{Z: zc},
+				"useridentities": &registryuseridentities.REST{Z: zc},
 			}
 
 			agi := genericserver.NewDefaultAPIGroupInfo(identityv1alpha1.SchemeGroupVersion.Group, scheme, metav1.ParameterCodec, codecs)

--- a/internal/apiserver/identity/useridentities/rest.go
+++ b/internal/apiserver/identity/useridentities/rest.go
@@ -1,4 +1,4 @@
-package identityproviders
+package useridentities
 
 import (
 	"context"


### PR DESCRIPTION
Fix typo in resource registration where the endpoint was registered as "identityproviders" instead of "useridentities", preventing the UserIdentity resource from being properly exposed in the API.

Changes:
- Rename directory: identityproviders → useridentities
- Update package name from identityproviders to useridentities
- Fix storage map registration to use "useridentities" key
- Update imports in command.go

This aligns the resource name with the actual type name (UserIdentity) defined in the Milo API schema.

Fixes: Resource not appearing in kubectl api-resources