### PR TITLE
feat(apiserver): authorize cross-user session/identity lookups via SAR to milo

### DIFF
--- a/cmd/apiserver/command.go
+++ b/cmd/apiserver/command.go
@@ -16,7 +16,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	authzv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	compatibility "k8s.io/component-base/compatibility"
 	"k8s.io/klog/v2"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
@@ -147,9 +150,34 @@ func NewAPIServerCommand(global *config.GlobalConfig) *cobra.Command {
 				return fmt.Errorf("init zitadel sdk: %w", err)
 			}
 
+			// Optional: build a SubjectAccessReviews client against milo
+			// for cross-user identity/session lookups. Loaded via the
+			// standard kube client config (KUBECONFIG env / --kubeconfig
+			// flag / in-cluster fallback) — same pattern the sibling
+			// authn-webhook Deployment uses (it sets KUBECONFIG to the
+			// milo kubeconfig path on the pod). If the loader can't find
+			// a valid config, we leave miloSAR nil and the REST handlers
+			// reject cross-user lookups with a clear error; self-only
+			// lookups still work.
+			var miloSAR authzv1client.SubjectAccessReviewInterface
+			restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+				clientcmd.NewDefaultClientConfigLoadingRules(),
+				&clientcmd.ConfigOverrides{},
+			).ClientConfig()
+			if err != nil {
+				log.Info("No kube client config found for milo SAR; cross-user identity/session lookups disabled", "reason", err.Error())
+			} else {
+				clientset, err := kubernetes.NewForConfig(restCfg)
+				if err != nil {
+					return fmt.Errorf("build milo clientset from kube client config: %w", err)
+				}
+				miloSAR = clientset.AuthorizationV1().SubjectAccessReviews()
+				log.Info("Cross-user identity/session lookups enabled via milo SAR", "host", restCfg.Host)
+			}
+
 			storage := map[string]rest.Storage{
-				"sessions":       &registrysessions.REST{Z: zc},
-				"useridentities": &registryuseridentities.REST{Z: zc},
+				"sessions":       &registrysessions.REST{Z: zc, MiloSAR: miloSAR},
+				"useridentities": &registryuseridentities.REST{Z: zc, MiloSAR: miloSAR},
 				"machineaccountkeys": &registrymachineaccountkeys.REST{
 					Z:                           zc,
 					EnableImpersonationFallback: enableImpersonationFallback,

--- a/internal/apiserver/identity/sessions/rest.go
+++ b/internal/apiserver/identity/sessions/rest.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -18,11 +19,25 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"go.miloapis.com/auth-provider-zitadel/internal/apiserver/identity/utils"
 	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
 	milov1alpha1 "go.miloapis.com/milo/pkg/apis/identity/v1alpha1"
 )
 
-type REST struct{ Z zitadel.API }
+// REST serves identity.miloapis.com/v1alpha1.Session backed by Zitadel.
+//
+// MiloSAR, when set, is consulted on List requests that include a
+// `status.userUID=<uid>` field selector targeting a user other than the
+// caller. The handler asks milo via SubjectAccessReview whether the caller
+// can `get iam.miloapis.com/users/<uid>` and proceeds iff allowed.
+//
+// If MiloSAR is nil, cross-user lookups are rejected with a clear error;
+// self-only behavior is unaffected. This lets deployments roll the binary
+// without the milo kubeconfig wired up and degrade gracefully.
+type REST struct {
+	Z       zitadel.API
+	MiloSAR utils.SubjectAccessReviewer
+}
 
 var _ rest.Scoper = &REST{}
 var _ rest.Lister = &REST{}
@@ -39,14 +54,49 @@ func (r *REST) New() runtime.Object     { return &milov1alpha1.Session{} }
 func (r *REST) NewList() runtime.Object { return &milov1alpha1.SessionList{} }
 func (r *REST) GetSingularName() string { return "session" }
 
-func (r *REST) List(ctx context.Context, _ *metainternal.ListOptions) (runtime.Object, error) {
+func (r *REST) List(ctx context.Context, options *metainternal.ListOptions) (runtime.Object, error) {
 	u, ok := request.UserFrom(ctx)
 	if !ok {
 		klog.ErrorS(nil, "No user in context for List")
 		return nil, apierrors.NewUnauthorized("no user in context")
 	}
+
+	// Default: list the caller's own sessions. If the caller passes a
+	// status.userUID field selector targeting a different user UID, ask
+	// milo (via SAR) whether the caller can `get` that user; proceed iff
+	// allowed.
 	uid := u.GetUID()
-	klog.V(2).InfoS("Listing sessions for user", "uid", uid)
+	if options != nil && options.FieldSelector != nil {
+		if targetUID, err := utils.ExtractUserUIDFromFieldSelector(options.FieldSelector); err == nil && targetUID != "" && targetUID != u.GetUID() {
+			if r.MiloSAR == nil {
+				klog.V(2).InfoS("Cross-user session lookup rejected: no milo SAR client configured",
+					"requestor", u.GetUID(), "targetUID", targetUID)
+				return nil, apierrors.NewForbidden(
+					sessionsGR,
+					"",
+					fmt.Errorf("cross-user session lookup requires the apiserver to be configured with a milo kubeconfig"))
+			}
+			allowed, err := utils.CanGetUser(ctx, r.MiloSAR, u, targetUID)
+			if err != nil {
+				klog.ErrorS(err, "SubjectAccessReview against milo failed",
+					"requestor", u.GetUID(), "targetUID", targetUID)
+				return nil, apierrors.NewInternalError(err)
+			}
+			if !allowed {
+				klog.V(2).InfoS("Unauthorized: caller cannot get target user in milo",
+					"requestor", u.GetUID(), "targetUID", targetUID)
+				return nil, apierrors.NewForbidden(
+					sessionsGR,
+					"",
+					fmt.Errorf("not authorized to query sessions for user %q (requires get on iam.miloapis.com/users)", targetUID))
+			}
+			klog.V(2).InfoS("Cross-user session lookup authorized by milo",
+				"requestor", u.GetUID(), "targetUID", targetUID)
+			uid = targetUID
+		}
+	}
+	klog.V(2).InfoS("Listing sessions", "uid", uid)
+
 	zs, err := r.Z.ListSessions(ctx, uid)
 	if err != nil {
 		klog.ErrorS(err, "Failed to list sessions", "uid", uid)

--- a/internal/apiserver/identity/useridentities/rest.go
+++ b/internal/apiserver/identity/useridentities/rest.go
@@ -2,6 +2,7 @@ package useridentities
 
 import (
 	"context"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -15,11 +16,24 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"go.miloapis.com/auth-provider-zitadel/internal/apiserver/identity/utils"
 	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
 	milov1alpha1 "go.miloapis.com/milo/pkg/apis/identity/v1alpha1"
 )
 
-type REST struct{ Z zitadel.API }
+// REST serves identity.miloapis.com/v1alpha1.UserIdentity backed by Zitadel.
+//
+// MiloSAR, when set, is consulted on List requests that include a
+// `status.userUID=<uid>` field selector targeting a user other than the
+// caller. The handler asks milo via SubjectAccessReview whether the caller
+// can `get iam.miloapis.com/users/<uid>` and proceeds iff allowed.
+//
+// If MiloSAR is nil, cross-user lookups are rejected with a clear error;
+// self-only behavior is unaffected.
+type REST struct {
+	Z       zitadel.API
+	MiloSAR utils.SubjectAccessReviewer
+}
 
 var _ rest.Scoper = &REST{}
 var _ rest.Lister = &REST{}
@@ -35,14 +49,48 @@ func (r *REST) New() runtime.Object     { return &milov1alpha1.UserIdentity{} }
 func (r *REST) NewList() runtime.Object { return &milov1alpha1.UserIdentityList{} }
 func (r *REST) GetSingularName() string { return "useridentity" }
 
-func (r *REST) List(ctx context.Context, _ *metainternal.ListOptions) (runtime.Object, error) {
+func (r *REST) List(ctx context.Context, options *metainternal.ListOptions) (runtime.Object, error) {
 	u, ok := request.UserFrom(ctx)
 	if !ok {
 		klog.ErrorS(nil, "No user in context for List")
 		return nil, apierrors.NewUnauthorized("no user in context")
 	}
+
+	// Default: list the caller's own identity links. If the caller passes
+	// a status.userUID field selector targeting a different user UID, ask
+	// milo (via SAR) whether the caller can `get` that user; proceed iff
+	// allowed.
 	uid := u.GetUID()
-	klog.V(2).InfoS("Listing identity providers for user", "uid", uid)
+	if options != nil && options.FieldSelector != nil {
+		if targetUID, err := utils.ExtractUserUIDFromFieldSelector(options.FieldSelector); err == nil && targetUID != "" && targetUID != u.GetUID() {
+			if r.MiloSAR == nil {
+				klog.V(2).InfoS("Cross-user identity lookup rejected: no milo SAR client configured",
+					"requestor", u.GetUID(), "targetUID", targetUID)
+				return nil, apierrors.NewForbidden(
+					userIdentitiesGR,
+					"",
+					fmt.Errorf("cross-user identity lookup requires the apiserver to be configured with a milo kubeconfig"))
+			}
+			allowed, err := utils.CanGetUser(ctx, r.MiloSAR, u, targetUID)
+			if err != nil {
+				klog.ErrorS(err, "SubjectAccessReview against milo failed",
+					"requestor", u.GetUID(), "targetUID", targetUID)
+				return nil, apierrors.NewInternalError(err)
+			}
+			if !allowed {
+				klog.V(2).InfoS("Unauthorized: caller cannot get target user in milo",
+					"requestor", u.GetUID(), "targetUID", targetUID)
+				return nil, apierrors.NewForbidden(
+					userIdentitiesGR,
+					"",
+					fmt.Errorf("not authorized to query identities for user %q (requires get on iam.miloapis.com/users)", targetUID))
+			}
+			klog.V(2).InfoS("Cross-user identity lookup authorized by milo",
+				"requestor", u.GetUID(), "targetUID", targetUID)
+			uid = targetUID
+		}
+	}
+	klog.V(2).InfoS("Listing identity providers", "uid", uid)
 
 	idpLinks, err := r.Z.ListIDPLinks(ctx, uid)
 	if err != nil {

--- a/internal/apiserver/identity/utils/utils.go
+++ b/internal/apiserver/identity/utils/utils.go
@@ -1,0 +1,98 @@
+// Package utils contains shared helpers for the identity REST handlers
+// (sessions, useridentities) that support staff users querying other users'
+// resources via a field selector. The default behavior of those handlers is
+// self-only (you can only see your own); when a field selector specifies a
+// different target user UID, the request is allowed iff the caller can
+// `get iam.miloapis.com/users/<targetUID>` on milo (verified via a
+// SubjectAccessReview against the milo apiserver).
+//
+// Authorization is intentionally delegated to milo rather than checked
+// in-process: this apiserver runs behind milo's front-proxy with an
+// AlwaysAllowAuthorizer, treating milo as the single Policy Decision Point.
+// The SAR call composes existing milo User RBAC instead of requiring this
+// binary to ship its own group allow-list.
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// ExtractUserUIDFromFieldSelector extracts the userUID value from a field
+// selector. Uses the kube-style nested path `status.userUID=<uid>` matching
+// the Session / UserIdentity status field. Returns an error if the selector
+// is empty or doesn't include a status.userUID requirement; callers should
+// treat that as "no target user specified" and fall back to the
+// authenticated user's UID.
+func ExtractUserUIDFromFieldSelector(selector fields.Selector) (string, error) {
+	if selector == nil || selector.Empty() {
+		return "", fmt.Errorf("empty field selector")
+	}
+	if req, found := selector.RequiresExactMatch("status.userUID"); found {
+		return req, nil
+	}
+	return "", fmt.Errorf("status.userUID not found in field selector")
+}
+
+// SubjectAccessReviewer is the minimal slice of the kube SAR client this
+// package needs. The standard
+// k8s.io/client-go/kubernetes.AuthorizationV1().SubjectAccessReviews()
+// satisfies it; this interface is here so handlers can be unit-tested with
+// a fake without pulling in the full clientset.
+type SubjectAccessReviewer interface {
+	Create(ctx context.Context, sar *authzv1.SubjectAccessReview, opts metav1.CreateOptions) (*authzv1.SubjectAccessReview, error)
+}
+
+// CanGetUser asks milo whether `caller` is authorized to GET the
+// iam.miloapis.com/users/<targetUID> resource. It is the per-request authz
+// gate for cross-user identity and session lookups.
+//
+// Composing on the existing User RBAC (rather than minting a new
+// "list-sessions-any-user" permission) means staff/admin roles that already
+// grant `get users` cluster-wide automatically get cross-user lookup, and
+// finer-grained roles that only grant `get users/<X>` only see X's
+// resources — same RBAC governs both layers.
+func CanGetUser(ctx context.Context, sar SubjectAccessReviewer, caller user.Info, targetUID string) (bool, error) {
+	if sar == nil {
+		return false, fmt.Errorf("no SubjectAccessReviewer configured")
+	}
+	if caller == nil {
+		return false, fmt.Errorf("no caller info in context")
+	}
+	review, err := sar.Create(ctx, &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User:   caller.GetName(),
+			UID:    caller.GetUID(),
+			Groups: caller.GetGroups(),
+			Extra:  toAuthzExtra(caller.GetExtra()),
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:     "get",
+				Group:    "iam.miloapis.com",
+				Resource: "users",
+				Name:     targetUID,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("subjectaccessreview against milo: %w", err)
+	}
+	return review.Status.Allowed, nil
+}
+
+// toAuthzExtra adapts user.Info.GetExtra() to the type expected by the
+// authorization API.
+func toAuthzExtra(extra map[string][]string) map[string]authzv1.ExtraValue {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string]authzv1.ExtraValue, len(extra))
+	for k, v := range extra {
+		out[k] = authzv1.ExtraValue(v)
+	}
+	return out
+}


### PR DESCRIPTION
Allow cross-user lookups of Sessions and UserIdentities, gated by a SubjectAccessReview against milo. Builds on @OscarLlamas6's original PR #69, refreshed against current main and reworked per @swells's design feedback.

## Behavior

- **No field selector** → existing behavior. Caller sees only their own resources.
- **`status.userUID=<uid>` targets caller's own UID** → existing behavior.
- **`status.userUID=<uid>` targets another UID** → handler issues a SubjectAccessReview to milo asking *"can the caller `get iam.miloapis.com/users/<uid>`?"*. If milo says yes, the request proceeds against the target UID; otherwise 403.

`Get` and `Delete` remain self-only — extending those is a separate question (staff-portal may want it; fraud-operator only needs `List`).

## Why SAR + milo, not in-process group check

This apiserver runs behind milo's front-proxy with an `AlwaysAllowAuthorizer`, treating milo as the single Policy Decision Point. Hardcoding an authorization decision into this binary would duplicate a concern that already has a home.

Composing on milo's existing User RBAC instead means:

- **No new permission shape to mint.** Staff/admin roles that already grant `get users` cluster-wide automatically get cross-user identity/session lookup. Finer-grained roles that grant `get users/<X>` see only X's resources — same RBAC governs both layers.
- **No staff-groups flag, no hard-coded allow-list.** Adding a new authorized identity is a milo PolicyBinding, not a redeploy of this binary.
- **Per-user scoping for free.** RBAC is the single mechanism.

Cost: one SAR roundtrip to milo per cross-user request. Caller already paid one to milo's front-proxy on the way in, so this is a doubling for cross-user requests but a no-op for self-lookups.

## Milo client wiring

The apiserver builds its milo SAR client from the **standard kube client config** at startup (`clientcmd.NewDefaultClientConfigLoadingRules`), which respects the `KUBECONFIG` env var with in-cluster fallback. Same pattern the sibling `authn-webhook` Deployment in this chart already uses (it sets `KUBECONFIG=/etc/milo-control-plane/config/kubeconfig`).

No new flag, no custom env var. Deployment overlay just sets `KUBECONFIG` to the milo kubeconfig path on the pod.

If the loader can't find a valid config, the apiserver logs a warning and the REST handlers reject cross-user lookups with a clear error; self-only behavior is unaffected. So deployments that don't wire `KUBECONFIG` continue to function exactly as today.

## Infra side (separate PR)

datum-cloud/infra#2283 mounts the existing `milo-control-plane-kubeconfig` ConfigMap on the apiserver Deployment and sets `KUBECONFIG` to point at it. The matching client cert (`system:control@identity.miloapis.com`, `system:masters`) is already mounted alongside as `milo-control-plane-certs`. No new infra primitives.

## Implementation

- New shared `internal/apiserver/identity/utils` package — `ExtractUserUIDFromFieldSelector`, the minimal `SubjectAccessReviewer` interface, and `CanGetUser` helper.
- `sessions.REST` and `useridentities.REST` get a `MiloSAR utils.SubjectAccessReviewer` field instead of a hardcoded group list.
- Apiserver wiring builds the SAR client from the default kube client loader at startup; nil if loader fails.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean.
- [x] Existing `internal/apiserver/identity/...` tests pass (machineaccountkeys; sessions and useridentities have no unit tests today).
- [ ] After the infra PR lands and the apiserver is redeployed with `KUBECONFIG` wired: confirm fraud-operator can list sessions for any user when its identity has `get iam.miloapis.com/users` cluster-wide.

## Refs
- Closes #69 (PR refresh)
- Pairs with datum-cloud/infra#2283
- Refs datum-cloud/fraud#28
- Refs datum-cloud/staff-portal#284
