### PR TITLE
Publish multi-arch (amd64 + arm64) container images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,10 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
       image-name: auth-provider-zitadel
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   publish-kustomize-bundles:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary

Our published container images are currently amd64-only. Developers on Apple Silicon (arm64) Macs have to rely on slow x86 emulation to run them locally, which makes dev and debug loops painful. This PR enables native arm64 images alongside amd64 so Apple Silicon users are unblocked and get near-native performance.

The change is small and targeted:
- Pin the Docker builder stage to the host's build platform so Go cross-compiles natively instead of running the compiler under QEMU emulation.
- Ask the shared publish workflow to build both `linux/amd64` and `linux/arm64`.

Local multi-arch build time: **~53 seconds** (down from 15+ minutes on the QEMU-emulated baseline).

## Test plan

- [ ] CI `publish-container-image` job succeeds on both `linux/amd64` and `linux/arm64`
- [ ] Published manifest lists both architectures (`docker buildx imagetools inspect`)
- [ ] Image runs on an arm64 host (Apple Silicon) without emulation
- [ ] Image still runs on an amd64 host
- [ ] `version` subcommand reports the injected VERSION / GIT_COMMIT / BUILD_DATE