### PR TITLE
fix: machine account creation in projects with existing Zitadel organizations

### DIFF
--- a/internal/apiserver/identity/machineaccountkeys/rest.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest.go
@@ -31,8 +31,7 @@ type REST struct {
 
 // getOrgID resolves the Zitadel organization ID from the request context.
 // The project name is extracted from Milo IAM parent extras or impersonation
-// extras, then prefixed with "project-" to form the org ID. This prefix avoids
-// collisions with infrastructure-managed Zitadel organizations.
+// extras, then converted to an org ID via zitadel.OrgIDForProject.
 func (r *REST) getOrgID(ctx context.Context) (string, bool) {
 	var projectName string
 
@@ -59,7 +58,7 @@ func (r *REST) getOrgID(ctx context.Context) (string, bool) {
 		return "", false
 	}
 
-	return "project-" + projectName, true
+	return zitadel.OrgIDForProject(projectName), true
 }
 
 var _ rest.Creater = &REST{} //nolint:misspell

--- a/internal/apiserver/identity/machineaccountkeys/rest.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest.go
@@ -29,32 +29,37 @@ type REST struct {
 	EnableImpersonationFallback bool
 }
 
-// getProjectID attempts to find the Project/Org ID from:
-//  1. Milo's IAM parent extras (set by ProjectContextAuthorizationDecorator for requests
-//     routed through /projects/{id}/control-plane/...)
-//  2. Kubernetes Impersonation Extras for local testing via:
-//     kubectl ... --as admin --as-extra=project=my-org-id
-func (r *REST) getProjectID(ctx context.Context) (string, bool) {
+// getOrgID resolves the Zitadel organization ID from the request context.
+// The project name is extracted from Milo IAM parent extras or impersonation
+// extras, then prefixed with "project-" to form the org ID. This prefix avoids
+// collisions with infrastructure-managed Zitadel organizations.
+func (r *REST) getOrgID(ctx context.Context) (string, bool) {
+	var projectName string
+
 	if userInfo, ok := request.UserFrom(ctx); ok {
 		extras := userInfo.GetExtra()
-		// Primary path: project ID forwarded as IAM parent extras by Milo's
+		// Primary path: project name forwarded as IAM parent extras by Milo's
 		// ProjectContextAuthorizationDecorator when routing via /projects/{id}/control-plane/...
 		if kinds := extras["iam.miloapis.com/parent-type"]; len(kinds) > 0 && kinds[0] == "Project" {
 			if names := extras["iam.miloapis.com/parent-name"]; len(names) > 0 && names[0] != "" {
-				return names[0], true
+				projectName = names[0]
 			}
 		}
 
 		// Fallback for local testing when running the apiserver outside of the ProjectRouter.
-		if r.EnableImpersonationFallback {
+		if projectName == "" && r.EnableImpersonationFallback {
 			if projects := extras["project"]; len(projects) > 0 && projects[0] != "" {
-				klog.V(4).InfoS("Found project ID from impersonation extras (local testing fallback)", "orgID", projects[0])
-				return projects[0], true
+				klog.V(4).InfoS("Found project name from impersonation extras (local testing fallback)", "projectName", projects[0])
+				projectName = projects[0]
 			}
 		}
 	}
 
-	return "", false
+	if projectName == "" {
+		return "", false
+	}
+
+	return "project-" + projectName, true
 }
 
 var _ rest.Creater = &REST{} //nolint:misspell
@@ -103,7 +108,7 @@ func (r *REST) Create(
 	}
 
 	// Extract organization ID from request context (set by ProjectRouter or Impersonation)
-	orgID, ok := r.getProjectID(ctx)
+	orgID, ok := r.getOrgID(ctx)
 	if !ok || orgID == "" {
 		klog.ErrorS(nil, "Missing organization ID in request context or impersonation extras")
 		return nil, apierrors.NewBadRequest("request must be made within a project context (/projects/{projectID}/control-plane/...) or use --as-extra=project={orgID} for testing")
@@ -262,7 +267,7 @@ func (r *REST) List(
 	ctx context.Context,
 	options *internalversion.ListOptions,
 ) (runtime.Object, error) {
-	orgID, ok := r.getProjectID(ctx)
+	orgID, ok := r.getOrgID(ctx)
 	if !ok || orgID == "" {
 		klog.ErrorS(nil, "Missing organization ID in request context")
 		return nil, apierrors.NewBadRequest("request must be made within a project context (/projects/{projectID}/control-plane/...) or use --as-extra=project={orgID} for testing")
@@ -437,7 +442,7 @@ func (r *REST) Delete(
 	deleteValidation rest.ValidateObjectFunc,
 	options *metav1.DeleteOptions,
 ) (runtime.Object, bool, error) {
-	orgID, ok := r.getProjectID(ctx)
+	orgID, ok := r.getOrgID(ctx)
 	if !ok || orgID == "" {
 		klog.ErrorS(nil, "Missing organization ID in request context")
 		return nil, false, apierrors.NewBadRequest("request must be made within a project context (/projects/{projectID}/control-plane/...) or use --as-extra=project={orgID} for testing")

--- a/internal/controller/machineaccount_controller.go
+++ b/internal/controller/machineaccount_controller.go
@@ -143,8 +143,10 @@ func (r *MachineAccountController) Reconcile(ctx context.Context, req mcreconcil
 
 	// Resolve the Zitadel Organization ID for this machine account's project.
 	// The cluster name is /{project-name}, so strip the leading / to get the project name.
-	// The project name is used as the Zitadel org ID.
-	orgID := strings.TrimPrefix(req.ClusterName, "/")
+	// The org ID is prefixed with "project-" to avoid collisions with
+	// infrastructure-managed Zitadel organizations that use the bare project name.
+	projectName := strings.TrimPrefix(req.ClusterName, "/")
+	orgID := "project-" + projectName
 	log.V(2).Info("Checking if Zitadel organization exists", "orgID", orgID)
 	org, err := r.Zitadel.GetOrganization(ctx, orgID)
 	if err != nil {
@@ -153,12 +155,12 @@ func (r *MachineAccountController) Reconcile(ctx context.Context, req mcreconcil
 	}
 
 	if org == nil {
-		log.Info("Zitadel Organization does not exist, creating it", "orgID", orgID)
-		if _, err := r.Zitadel.CreateOrganizationWithID(ctx, orgID, orgID); err != nil {
+		log.Info("Zitadel Organization does not exist, creating it", "orgID", orgID, "displayName", projectName)
+		if _, err := r.Zitadel.CreateOrganizationWithID(ctx, projectName, orgID); err != nil {
 			log.Error(err, "Failed to create Zitadel Organization", "orgID", orgID)
 			return ctrl.Result{}, fmt.Errorf("create organization: %w", err)
 		}
-		log.Info("Successfully created Zitadel Organization", "orgID", orgID)
+		log.Info("Successfully created Zitadel Organization", "orgID", orgID, "displayName", projectName)
 	}
 
 	maComputedEmail := r.computeEmailAddress(machineAccount, req)

--- a/internal/controller/machineaccount_controller.go
+++ b/internal/controller/machineaccount_controller.go
@@ -143,10 +143,10 @@ func (r *MachineAccountController) Reconcile(ctx context.Context, req mcreconcil
 
 	// Resolve the Zitadel Organization ID for this machine account's project.
 	// The cluster name is /{project-name}, so strip the leading / to get the project name.
-	// The org ID is prefixed with "project-" to avoid collisions with
-	// infrastructure-managed Zitadel organizations that use the bare project name.
+	// The org ID is prefixed to avoid collisions with infrastructure-managed
+	// Zitadel organizations that use the bare project name.
 	projectName := strings.TrimPrefix(req.ClusterName, "/")
-	orgID := "project-" + projectName
+	orgID := pkgzitadel.OrgIDForProject(projectName)
 	log.V(2).Info("Checking if Zitadel organization exists", "orgID", orgID)
 	org, err := r.Zitadel.GetOrganization(ctx, orgID)
 	if err != nil {

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -61,7 +61,7 @@ func (f *projectFinalizer) Finalize(ctx context.Context, obj client.Object) (fin
 		return finalizer.Result{}, err
 	}
 
-	orgID := "project-" + project.GetName()
+	orgID := pkgzitadel.OrgIDForProject(project.GetName())
 	log.Info("Deleting Zitadel Organization", "orgID", orgID)
 
 	err := f.Zitadel.DeleteOrganization(ctx, orgID)

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -61,16 +61,16 @@ func (f *projectFinalizer) Finalize(ctx context.Context, obj client.Object) (fin
 		return finalizer.Result{}, err
 	}
 
-	projectName := project.GetName()
-	log.Info("Deleting Zitadel Organization", "projectName", projectName)
+	orgID := "project-" + project.GetName()
+	log.Info("Deleting Zitadel Organization", "orgID", orgID)
 
-	err := f.Zitadel.DeleteOrganization(ctx, projectName)
+	err := f.Zitadel.DeleteOrganization(ctx, orgID)
 	if err != nil {
-		log.Error(err, "Failed to delete Zitadel Organization", "orgID", projectName)
+		log.Error(err, "Failed to delete Zitadel Organization", "orgID", orgID)
 		return finalizer.Result{}, fmt.Errorf("delete organization: %w", err)
 	}
 
-	log.Info("Successfully finalized Project", "projectName", projectName)
+	log.Info("Successfully finalized Project", "orgID", orgID)
 	return finalizer.Result{}, nil
 }
 

--- a/pkg/zitadel/api.go
+++ b/pkg/zitadel/api.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+// OrgIDForProject returns the Zitadel organization ID for a given project name.
+// The "project-" prefix ensures the controller's org does not collide with
+// infrastructure-managed organizations that use the bare project name.
+func OrgIDForProject(projectName string) string {
+	return "project-" + projectName
+}
+
 // Session represents a Zitadel session distilled for Kubernetes exposure.
 type Session struct {
 	ID            string


### PR DESCRIPTION
## Summary

When creating a machine account in the `datum-cloud` project, the controller fails with a "Domain already exists" error. This happens because the controller uses the project name as the Zitadel organization ID, but an organization named `datum-cloud` already exists — it was provisioned by infrastructure for our platform applications.

This adds a `project-` prefix to the org ID used by the controller (e.g. `project-datum-cloud`), giving it a dedicated namespace that won't conflict with infrastructure-managed organizations. The project name is still used as the display name for readability.

## Test plan

- [ ] Create a machine account in a project with an existing Zitadel organization
- [ ] Verify machine account keys can be created, listed, and deleted
- [ ] Delete a project and verify cleanup completes successfully

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)