### PR TITLE
fix: use unique display name for project Zitadel organizations

### DIFF
--- a/internal/controller/machineaccount_controller.go
+++ b/internal/controller/machineaccount_controller.go
@@ -155,12 +155,13 @@ func (r *MachineAccountController) Reconcile(ctx context.Context, req mcreconcil
 	}
 
 	if org == nil {
-		log.Info("Zitadel Organization does not exist, creating it", "orgID", orgID, "displayName", projectName)
-		if _, err := r.Zitadel.CreateOrganizationWithID(ctx, projectName, orgID); err != nil {
+		displayName := pkgzitadel.OrgDisplayNameForProject(projectName)
+		log.Info("Zitadel Organization does not exist, creating it", "orgID", orgID, "displayName", displayName)
+		if _, err := r.Zitadel.CreateOrganizationWithID(ctx, displayName, orgID); err != nil {
 			log.Error(err, "Failed to create Zitadel Organization", "orgID", orgID)
 			return ctrl.Result{}, fmt.Errorf("create organization: %w", err)
 		}
-		log.Info("Successfully created Zitadel Organization", "orgID", orgID, "displayName", projectName)
+		log.Info("Successfully created Zitadel Organization", "orgID", orgID, "displayName", displayName)
 	}
 
 	maComputedEmail := r.computeEmailAddress(machineAccount, req)

--- a/pkg/zitadel/api.go
+++ b/pkg/zitadel/api.go
@@ -12,6 +12,14 @@ func OrgIDForProject(projectName string) string {
 	return "project-" + projectName
 }
 
+// OrgDisplayNameForProject returns the display name used when creating a
+// Zitadel organization for a project. The "Project - " prefix keeps the
+// display name unique from the bare project name that Zitadel already
+// reserves as a domain label on the old (un-prefixed) organization.
+func OrgDisplayNameForProject(projectName string) string {
+	return "Project - " + projectName
+}
+
 // Session represents a Zitadel session distilled for Kubernetes exposure.
 type Session struct {
 	ID            string


### PR DESCRIPTION
## Summary
- The `project-` prefixed org ID from #94 causes `AlreadyExists` errors in staging because Zitadel enforces unique org **names**, and the bare project name is already taken by the existing un-prefixed org
- Adds `OrgDisplayNameForProject()` helper that returns `"Project - {name}"` as the display name, avoiding the name collision while keeping the prefixed org ID

## Test plan
- [ ] Verify the controller successfully creates new `project-`-prefixed orgs in staging without `AlreadyExists` errors
- [ ] Confirm controller logs show the new `"Project - {name}"` display name
- [ ] Check that existing machine account reconciliation completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)