### PR TITLE
fix: return Datum credentials file from MachineAccountKey response

### DIFF
--- a/internal/apiserver/identity/machineaccountkeys/rest.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest.go
@@ -85,10 +85,10 @@ func (r *REST) GetSingularName() string { return "machineaccountkey" }
 // The machine account user ID is looked up from Zitadel using the machine account name.
 //
 // Returns the MachineAccountKey with:
-// - status.authProviderKeyID: the key ID from Zitadel
-// - status.privateKey: a Datum credentials file (JSON) when Zitadel generated
-//   the key material. Empty when the caller supplied their own public key, in
-//   which case the caller already holds the private key.
+//   - status.authProviderKeyID: the key ID from Zitadel
+//   - status.privateKey: a Datum credentials file (JSON) when Zitadel generated
+//     the key material. Empty when the caller supplied their own public key, in
+//     which case the caller already holds the private key.
 func (r *REST) Create(
 	ctx context.Context,
 	obj runtime.Object,

--- a/internal/apiserver/identity/machineaccountkeys/rest.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"time"
@@ -85,7 +86,9 @@ func (r *REST) GetSingularName() string { return "machineaccountkey" }
 //
 // Returns the MachineAccountKey with:
 // - status.authProviderKeyID: the key ID from Zitadel
-// - status.privateKey: the generated or provided key content/payload from Zitadel
+// - status.privateKey: a Datum credentials file (JSON) when Zitadel generated
+//   the key material. Empty when the caller supplied their own public key, in
+//   which case the caller already holds the private key.
 func (r *REST) Create(
 	ctx context.Context,
 	obj runtime.Object,
@@ -161,9 +164,19 @@ func (r *REST) Create(
 		return nil, translateErr(err, mak.Name)
 	}
 
-	// Populate the status with the returned key ID and key content
+	// Populate status. When Zitadel generated the key material, transform its
+	// native envelope into the Datum credentials file format expected by
+	// datumctl and other Datum tooling. When the caller supplied their own
+	// public key, Zitadel returns no key content and status.privateKey is
+	// left empty.
+	credsJSON, err := buildDatumCredentials(keyContent, keyID, userID, mak.Spec.MachineAccountUserName)
+	if err != nil {
+		klog.ErrorS(err, "Failed to build Datum credentials response", "orgID", orgID, "userID", userID, "keyID", keyID)
+		return nil, apierrors.NewInternalError(fmt.Errorf("failed to build credentials response"))
+	}
+
 	mak.Status.AuthProviderKeyID = keyID
-	mak.Status.PrivateKey = string(keyContent)
+	mak.Status.PrivateKey = string(credsJSON)
 
 	klog.V(2).Infof("Machine account key created successfully: keyID=%s, machineAccount=%s, org=%s", keyID, mak.Spec.MachineAccountUserName, orgID)
 
@@ -205,6 +218,52 @@ func addMachineKeysToList(list *milov1alpha1.MachineAccountKeyList, machineAccou
 		}
 		list.Items = append(list.Items, item)
 	}
+}
+
+// datumCredentialsType is the `type` discriminator written to the credentials
+// file so tooling can recognize a Datum machine account credentials blob.
+const datumCredentialsType = "datum_machine_account"
+
+// datumCredentials is the credentials file format written to
+// MachineAccountKey.status.privateKey. It matches the shape expected by
+// datumctl's `auth login --credentials` flow.
+type datumCredentials struct {
+	Type         string `json:"type"`
+	ClientID     string `json:"client_id"`
+	PrivateKeyID string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"`
+	ClientEmail  string `json:"client_email,omitempty"`
+}
+
+// zitadelKeyEnvelope is the JSON envelope Zitadel returns as keyContent when
+// it generates the private key material. Only the PEM `key` field is
+// extracted here — the other values (keyId, userId) are already available
+// to the REST handler as separate parameters and do not need re-parsing.
+type zitadelKeyEnvelope struct {
+	Key string `json:"key"`
+}
+
+// buildDatumCredentials transforms Zitadel's AddKey keyContent payload into
+// the Datum credentials file format. When keyContent is empty (the caller
+// supplied their own public key and Zitadel therefore did not generate a
+// private key), it returns nil so status.privateKey stays empty.
+func buildDatumCredentials(keyContent []byte, keyID, clientID, clientEmail string) ([]byte, error) {
+	if len(keyContent) == 0 {
+		return nil, nil
+	}
+
+	var env zitadelKeyEnvelope
+	if err := json.Unmarshal(keyContent, &env); err != nil {
+		return nil, fmt.Errorf("parse zitadel key envelope: %w", err)
+	}
+
+	return json.Marshal(datumCredentials{
+		Type:         datumCredentialsType,
+		ClientID:     clientID,
+		PrivateKeyID: keyID,
+		PrivateKey:   env.Key,
+		ClientEmail:  clientEmail,
+	})
 }
 
 // validatePublicKey validates that the public key is in valid PEM format

--- a/test/machineaccountkey-generation/chainsaw-test.yaml
+++ b/test/machineaccountkey-generation/chainsaw-test.yaml
@@ -58,9 +58,34 @@ spec:
             exit 1
           fi
 
-          printf '%s\n' "$PRIVATE_KEY_JSON" | base64 -d > /tmp/zitadel-key-gen.json || printf '%s\n' "$PRIVATE_KEY_JSON" > /tmp/zitadel-key-gen.json
-          
-          echo "Successfully created MachineAccountKey and captured the privateKey payload!"
+          # status.privateKey is the Datum credentials file format used by
+          # datumctl. Support the same base64-or-raw fallback the old test had
+          # in case transports re-encode the field.
+          printf '%s\n' "$PRIVATE_KEY_JSON" | base64 -d > /tmp/datum-credentials.json 2>/dev/null || printf '%s\n' "$PRIVATE_KEY_JSON" > /tmp/datum-credentials.json
+
+          # Verify the Datum credentials file has all required fields.
+          CREDS_TYPE=$(jq -r '.type' /tmp/datum-credentials.json)
+          if [ "$CREDS_TYPE" != "datum_machine_account" ]; then
+            echo "ERROR: Expected credentials type 'datum_machine_account', got '$CREDS_TYPE'"
+            cat /tmp/datum-credentials.json
+            exit 1
+          fi
+          for field in client_id private_key_id private_key client_email; do
+            VALUE=$(jq -r ".${field}" /tmp/datum-credentials.json)
+            if [ -z "$VALUE" ] || [ "$VALUE" == "null" ]; then
+              echo "ERROR: Datum credentials missing required field: $field"
+              cat /tmp/datum-credentials.json
+              exit 1
+            fi
+          done
+
+          # Convert the Datum credentials to Zitadel's native key-file format so
+          # zitadel-tools key2jwt (which expects Zitadel's shape) can sign a
+          # JWT assertion from the generated private key in the next step.
+          jq '{type: "serviceaccount", keyId: .private_key_id, key: .private_key, userId: .client_id}' \
+            /tmp/datum-credentials.json > /tmp/zitadel-key-gen.json
+
+          echo "Successfully created MachineAccountKey and captured the Datum credentials payload!"
 
   - name: verify-generated-key-works
     try:


### PR DESCRIPTION
## Summary

Creating a `MachineAccountKey` now returns a ready-to-use Datum credentials file in `status.privateKey` instead of Zitadel's raw key envelope. Customers can save that file and pass it straight to `datumctl auth login --credentials` without any manual field remapping.

## What changed

- When Zitadel generates the key material, the handler transforms the payload into the Datum credentials shape (`type`, `client_id`, `private_key_id`, `private_key`, `client_email`) before writing it to status.
- When the caller supplied their own public key, `status.privateKey` stays empty (Zitadel returns no private key in that case, and the caller already holds it).
- The key-generation integration test now verifies the new format and converts it back to Zitadel's native shape for the downstream `zitadel-tools key2jwt` signing step.

Fixes datum-cloud/auth-provider-zitadel#96.

## Test plan

- [ ] Unit + vet: `go build ./... && go vet ./...`
- [ ] Chainsaw `machineaccountkey-generation` test (verifies credentials fields, then signs a JWT and exchanges it for an access token end-to-end)
- [ ] Chainsaw `machineaccountkey` lifecycle test (user-supplied publicKey path — unchanged behavior, `status.privateKey` remains empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)