### PR TITLE
fix: machine account logins can now call the Datum API

### DIFF
--- a/cmd/apiserver/command.go
+++ b/cmd/apiserver/command.go
@@ -54,6 +54,7 @@ func NewAPIServerCommand(global *config.GlobalConfig) *cobra.Command {
 		zitadelAPI                       string
 		zitadelKeyPath                   string
 		zitadelDefaultMachineKeyExpirary time.Duration
+		zitadelIntrospectionProjectID    string
 		// Local testing override
 		enableImpersonationFallback bool
 	)
@@ -149,7 +150,11 @@ func NewAPIServerCommand(global *config.GlobalConfig) *cobra.Command {
 			storage := map[string]rest.Storage{
 				"sessions":           &registrysessions.REST{Z: zc},
 				"useridentities":     &registryuseridentities.REST{Z: zc},
-				"machineaccountkeys": &registrymachineaccountkeys.REST{Z: zc, EnableImpersonationFallback: enableImpersonationFallback},
+				"machineaccountkeys": &registrymachineaccountkeys.REST{
+					Z:                           zc,
+					EnableImpersonationFallback: enableImpersonationFallback,
+					IntrospectionProjectID:      zitadelIntrospectionProjectID,
+				},
 			}
 
 			agi := genericserver.NewDefaultAPIGroupInfo(identityv1alpha1.SchemeGroupVersion.Group, scheme, metav1.ParameterCodec, codecs)
@@ -177,6 +182,7 @@ func NewAPIServerCommand(global *config.GlobalConfig) *cobra.Command {
 	cmd.Flags().StringVar(&zitadelAPI, "zitadel-api", "", "Zitadel API base URL")
 	cmd.Flags().StringVar(&zitadelKeyPath, "zitadel-key", "", "Path to Zitadel machine account key")
 	cmd.Flags().DurationVar(&zitadelDefaultMachineKeyExpirary, "zitadel-default-machine-key-expiration", 10*365*24*time.Hour, "The default duration for machine account keys (defaults to 10 years)")
+	cmd.Flags().StringVar(&zitadelIntrospectionProjectID, "zitadel-introspection-project-id", "", "Numeric Zitadel project ID (e.g. 326089123456789012) that the authn webhook's introspection client is a member of. When set, generated machine account credentials include an audience scope for this project so their tokens can be introspected. Leave empty to preserve prior behavior.")
 	cmd.Flags().BoolVar(&enableImpersonationFallback, "enable-impersonation-fallback", false, "Enable looking up project ID from k8s impersonation extras (for local testing without Milo proxy)")
 
 	// Wire klog flags to this command so users can set verbosity with -v=N

--- a/internal/apiserver/identity/machineaccountkeys/rest.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest.go
@@ -28,6 +28,12 @@ import (
 type REST struct {
 	Z                           zitadel.API
 	EnableImpersonationFallback bool
+	// IntrospectionProjectID is the Zitadel project ID the authn webhook's
+	// introspection client is a member of. When set, generated machine
+	// account credentials include an audience scope for this project so
+	// their tokens can be introspected. When empty, no scope field is
+	// emitted (caller-supplied keys or older deployments).
+	IntrospectionProjectID string
 }
 
 // getOrgID resolves the Zitadel organization ID from the request context.
@@ -169,7 +175,7 @@ func (r *REST) Create(
 	// datumctl and other Datum tooling. When the caller supplied their own
 	// public key, Zitadel returns no key content and status.privateKey is
 	// left empty.
-	credsJSON, err := buildDatumCredentials(keyContent, keyID, userID, mak.Spec.MachineAccountUserName)
+	credsJSON, err := buildDatumCredentials(keyContent, keyID, userID, mak.Spec.MachineAccountUserName, r.IntrospectionProjectID)
 	if err != nil {
 		klog.ErrorS(err, "Failed to build Datum credentials response", "orgID", orgID, "userID", userID, "keyID", keyID)
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to build credentials response"))
@@ -224,6 +230,11 @@ func addMachineKeysToList(list *milov1alpha1.MachineAccountKeyList, machineAccou
 // file so tooling can recognize a Datum machine account credentials blob.
 const datumCredentialsType = "datum_machine_account"
 
+// defaultMachineAccountScopes are the OIDC scopes always included in the
+// generated credentials file. The audience URN for the introspection
+// project is appended by buildDatumCredentials when configured.
+const defaultMachineAccountScopes = "openid profile email offline_access"
+
 // datumCredentials is the credentials file format written to
 // MachineAccountKey.status.privateKey. It matches the shape expected by
 // datumctl's `auth login --credentials` flow.
@@ -233,6 +244,7 @@ type datumCredentials struct {
 	PrivateKeyID string `json:"private_key_id"`
 	PrivateKey   string `json:"private_key"`
 	ClientEmail  string `json:"client_email,omitempty"`
+	Scope        string `json:"scope,omitempty"`
 }
 
 // zitadelKeyEnvelope is the JSON envelope Zitadel returns as keyContent when
@@ -247,7 +259,13 @@ type zitadelKeyEnvelope struct {
 // the Datum credentials file format. When keyContent is empty (the caller
 // supplied their own public key and Zitadel therefore did not generate a
 // private key), it returns nil so status.privateKey stays empty.
-func buildDatumCredentials(keyContent []byte, keyID, clientID, clientEmail string) ([]byte, error) {
+//
+// When introspectionProjectID is non-empty, the returned credentials include
+// a `scope` field containing the default OIDC scopes plus an audience URN
+// for the given Zitadel project, so tokens minted with these credentials can
+// be introspected by the authn webhook. When empty, the `scope` field is
+// omitted to preserve prior behavior.
+func buildDatumCredentials(keyContent []byte, keyID, clientID, clientEmail, introspectionProjectID string) ([]byte, error) {
 	if len(keyContent) == 0 {
 		return nil, nil
 	}
@@ -257,13 +275,18 @@ func buildDatumCredentials(keyContent []byte, keyID, clientID, clientEmail strin
 		return nil, fmt.Errorf("parse zitadel key envelope: %w", err)
 	}
 
-	return json.Marshal(datumCredentials{
+	creds := datumCredentials{
 		Type:         datumCredentialsType,
 		ClientID:     clientID,
 		PrivateKeyID: keyID,
 		PrivateKey:   env.Key,
 		ClientEmail:  clientEmail,
-	})
+	}
+	if introspectionProjectID != "" {
+		creds.Scope = defaultMachineAccountScopes + " urn:zitadel:iam:org:project:id:" + introspectionProjectID + ":aud"
+	}
+
+	return json.Marshal(creds)
 }
 
 // validatePublicKey validates that the public key is in valid PEM format

--- a/internal/apiserver/identity/machineaccountkeys/rest_test.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest_test.go
@@ -1,0 +1,114 @@
+package machineaccountkeys
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildDatumCredentials_EmptyKeyContent(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		introspectionProjectID string
+	}{
+		{name: "empty project ID", introspectionProjectID: ""},
+		{name: "with project ID", introspectionProjectID: "326089123456789012"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildDatumCredentials(nil, "key-id", "client-id", "client-email", tc.introspectionProjectID)
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if got != nil {
+				t.Fatalf("expected nil bytes for empty keyContent, got %q", string(got))
+			}
+
+			// Also verify with an explicit empty (non-nil) slice.
+			got, err = buildDatumCredentials([]byte{}, "key-id", "client-id", "client-email", tc.introspectionProjectID)
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if got != nil {
+				t.Fatalf("expected nil bytes for empty keyContent slice, got %q", string(got))
+			}
+		})
+	}
+}
+
+func TestBuildDatumCredentials_NoScopeWhenProjectIDEmpty(t *testing.T) {
+	envelope := []byte(`{"type":"sa","keyId":"k1","key":"-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----\n","userId":"u1"}`)
+
+	got, err := buildDatumCredentials(envelope, "key-id-1", "client-id-1", "svc@example.com", "")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil credentials, got nil")
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("failed to unmarshal credentials: %v", err)
+	}
+
+	if _, exists := m["scope"]; exists {
+		t.Fatalf("expected scope field to be absent, but it exists with value %v", m["scope"])
+	}
+
+	// Sanity check other required fields.
+	if m["type"] != datumCredentialsType {
+		t.Errorf("expected type=%q, got %v", datumCredentialsType, m["type"])
+	}
+	if m["client_id"] != "client-id-1" {
+		t.Errorf("expected client_id=client-id-1, got %v", m["client_id"])
+	}
+	if m["private_key_id"] != "key-id-1" {
+		t.Errorf("expected private_key_id=key-id-1, got %v", m["private_key_id"])
+	}
+	if m["client_email"] != "svc@example.com" {
+		t.Errorf("expected client_email=svc@example.com, got %v", m["client_email"])
+	}
+	if _, ok := m["private_key"].(string); !ok {
+		t.Errorf("expected private_key to be a string, got %T", m["private_key"])
+	}
+}
+
+func TestBuildDatumCredentials_ScopeWhenProjectIDSet(t *testing.T) {
+	envelope := []byte(`{"type":"sa","keyId":"k1","key":"-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----\n","userId":"u1"}`)
+	const projectID = "326089123456789012"
+	const wantScope = "openid profile email offline_access urn:zitadel:iam:org:project:id:326089123456789012:aud"
+
+	got, err := buildDatumCredentials(envelope, "key-id-1", "client-id-1", "svc@example.com", projectID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil credentials, got nil")
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("failed to unmarshal credentials: %v", err)
+	}
+
+	scope, ok := m["scope"].(string)
+	if !ok {
+		t.Fatalf("expected scope field to be a string, got %T (%v)", m["scope"], m["scope"])
+	}
+	if scope != wantScope {
+		t.Errorf("unexpected scope value\n  got:  %q\n want: %q", scope, wantScope)
+	}
+}
+
+func TestBuildDatumCredentials_MalformedJSON(t *testing.T) {
+	bad := []byte(`{not valid json`)
+
+	got, err := buildDatumCredentials(bad, "key-id", "client-id", "client-email", "")
+	if err == nil {
+		t.Fatalf("expected error for malformed JSON, got nil (bytes=%q)", string(got))
+	}
+	if got != nil {
+		t.Errorf("expected nil bytes on error, got %q", string(got))
+	}
+}


### PR DESCRIPTION
## Summary

Logging into Datum with a machine account key currently returns 401 on every subsequent API call. The access token looks valid, but the authentication webhook can't introspect it, so the API server rejects the request.

This change fixes that login flow. Once shipped, `datumctl auth login --credentials ./my-key.json` followed by `datumctl api-resources` will work end-to-end for machine accounts, just like interactive user logins already do.

No `datumctl` update is required — any reasonably recent version will automatically pick up the fix as soon as this ships.

## Operator note

A new optional flag `--zitadel-introspection-project-id` has been added to the apiserver command. Set it to the Zitadel project ID that the authn webhook's introspection client is a member of. If left unset, the behavior is unchanged from today.

Fixes #98

## Test plan

- [ ] Deploy to staging with `--zitadel-introspection-project-id` set
- [ ] Create a `MachineAccountKey` and confirm the returned credentials file includes a `scope` field
- [ ] Run `datumctl auth login --credentials` followed by `datumctl api-resources` and confirm it succeeds
- [ ] Confirm existing interactive user logins are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)