### PR TITLE
chore: finish wiring introspection project ID flag + gofmt fix

### DIFF
--- a/cmd/apiserver/command.go
+++ b/cmd/apiserver/command.go
@@ -148,8 +148,8 @@ func NewAPIServerCommand(global *config.GlobalConfig) *cobra.Command {
 			}
 
 			storage := map[string]rest.Storage{
-				"sessions":           &registrysessions.REST{Z: zc},
-				"useridentities":     &registryuseridentities.REST{Z: zc},
+				"sessions":       &registrysessions.REST{Z: zc},
+				"useridentities": &registryuseridentities.REST{Z: zc},
 				"machineaccountkeys": &registrymachineaccountkeys.REST{
 					Z:                           zc,
 					EnableImpersonationFallback: enableImpersonationFallback,

--- a/config/base/services/apiserver/deployment.yaml
+++ b/config/base/services/apiserver/deployment.yaml
@@ -38,6 +38,7 @@ spec:
             - --zitadel-issuer=$(ZITADEL_ISSUER)
             - --zitadel-api=$(ZITADEL_API)
             - --zitadel-key=$(ZITADEL_MACHINE_ACCOUNT_KEY_PATH)
+            - --zitadel-introspection-project-id=$(ZITADEL_INTROSPECTION_PROJECT_ID)
             - -v=4
             - --enable-impersonation-fallback=$(ENABLE_IMPERSONATION_FALLBACK)
           env:
@@ -51,6 +52,8 @@ spec:
               value: "zitadel.datum-cloud.com"
             - name: ZITADEL_MACHINE_ACCOUNT_KEY_PATH
               value: "/etc/zitadel/machine-account-key.json"
+            - name: ZITADEL_INTROSPECTION_PROJECT_ID
+              value: ""
             - name: TLS_CERT_FILE
               value: /etc/kubernetes/pki/client/tls.crt
             - name: TLS_PRIVATE_KEY_FILE


### PR DESCRIPTION
## Summary

Follow-up to #99 (which landed the core fix for #98). Two commits that didn't make it into that merge:

- **gofmt fix** for `cmd/apiserver/command.go` — the `Lint` job is currently failing on `main` because of this.
- **Wire `--zitadel-introspection-project-id` through the kustomize base deployment** via a new `ZITADEL_INTROSPECTION_PROJECT_ID` env var (empty default). Without this, infra-repo patches have nothing to override — the flag is set on the Go command but never actually passed to the container.

Unblocks the introspection-project-id change from landing end-to-end.

## Test plan

- [ ] `Lint` goes green (it's red on main right now)
- [ ] Build, vet, tests all pass
- [ ] Once merged: the new kustomize bundle ships via the usual OCI flow and the infra-repo patch (separate PR in datum-cloud/infra) can source the value from the `datum-cloud-project-id` ConfigMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)