### PR TITLE
fix: wrong machine account field name

### DIFF
--- a/config/samples/machineaccountkey_1.yaml
+++ b/config/samples/machineaccountkey_1.yaml
@@ -1,10 +1,10 @@
-apiVersion: iam.miloapis.com/v1alpha1
+apiVersion: identity.miloapis.com/v1alpha1
 kind: MachineAccountKey
 metadata:
   name: example-service-account-key
   namespace: default
 spec:
-  machineAccountName: example-service-account
+  machineAccountUserName: example-service-account
   publicKey: |
     -----BEGIN PUBLIC KEY-----
     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhzwVTAVK4fmo0BjUS/co

--- a/config/samples/machineaccountkey_2.yaml
+++ b/config/samples/machineaccountkey_2.yaml
@@ -1,10 +1,10 @@
-apiVersion: iam.miloapis.com/v1alpha1
+apiVersion: identity.miloapis.com/v1alpha1
 kind: MachineAccountKey
 metadata:
   name: example-service-account-key
   namespace: default
 spec:
-  machineAccountName: example-service-account
+  machineAccountUserName: example-service-account
   publicKey: |
     -----BEGIN PUBLIC KEY-----
     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7lUPB1oC5fC81f6RYGRt

--- a/internal/apiserver/identity/machineaccountkeys/rest.go
+++ b/internal/apiserver/identity/machineaccountkeys/rest.go
@@ -111,8 +111,8 @@ func (r *REST) Create(
 
 	// Validate required fields
 	if mak.Spec.MachineAccountUserName == "" {
-		klog.ErrorS(nil, "Missing required field: machineAccountName")
-		return nil, apierrors.NewBadRequest("machineAccountName is required")
+		klog.ErrorS(nil, "Missing required field: machineAccountUserName")
+		return nil, apierrors.NewBadRequest("machineAccountUserName is required")
 	}
 
 	// Extract organization ID from request context (set by ProjectRouter or Impersonation)


### PR DESCRIPTION
This PR fixes the samples for the machineAccountKeys and the error response wording when the machineAccountUsername is missing.