### PR TITLE
fix(apiserver): register status.userUID field selector for Session/UserIdentity

### DIFF
--- a/pkg/apis/identity/scheme.go
+++ b/pkg/apis/identity/scheme.go
@@ -7,12 +7,14 @@ import (
 	milov1alpha1 "go.miloapis.com/milo/pkg/apis/identity/v1alpha1"
 )
 
-// Install registers provider group/version bindings for Milo Session types.
+// Install registers provider group/version bindings for Milo identity types and
+// declares which field selectors the aggregated apiserver should pass through to
+// the REST handlers (otherwise the generic apiserver rejects them at request
+// validation with "is not a known field selector: only metadata.name,
+// metadata.namespace").
 func Install(s *runtime.Scheme) {
 	_ = milov1alpha1.AddToScheme(s)
 
-	// Register valid field selectors for MachineAccountKey so the generic API server
-	// passes them through to the REST handler instead of intercepting them.
 	_ = s.AddFieldLabelConversionFunc(
 		schema.GroupVersionKind{
 			Group:   milov1alpha1.SchemeGroupVersion.Group,
@@ -27,5 +29,36 @@ func Install(s *runtime.Scheme) {
 				return "", "", nil
 			}
 		},
+	)
+
+	// Sessions and UserIdentities are listed by callers using
+	// status.userUID=<uid> for cross-user lookups (gated by SAR in the REST
+	// handler). Without this registration the apiserver pre-rejects the
+	// selector before the handler ever sees it.
+	sessionUserIDConversion := func(label, value string) (string, string, error) {
+		switch label {
+		case "status.userUID", "metadata.name", "metadata.namespace":
+			return label, value, nil
+		default:
+			return "", "", nil
+		}
+	}
+
+	_ = s.AddFieldLabelConversionFunc(
+		schema.GroupVersionKind{
+			Group:   milov1alpha1.SchemeGroupVersion.Group,
+			Version: milov1alpha1.SchemeGroupVersion.Version,
+			Kind:    "Session",
+		},
+		sessionUserIDConversion,
+	)
+
+	_ = s.AddFieldLabelConversionFunc(
+		schema.GroupVersionKind{
+			Group:   milov1alpha1.SchemeGroupVersion.Group,
+			Version: milov1alpha1.SchemeGroupVersion.Version,
+			Kind:    "UserIdentity",
+		},
+		sessionUserIDConversion,
 	)
 }

--- a/pkg/apis/identity/scheme.go
+++ b/pkg/apis/identity/scheme.go
@@ -31,34 +31,23 @@ func Install(s *runtime.Scheme) {
 		},
 	)
 
-	// Sessions and UserIdentities are listed by callers using
-	// status.userUID=<uid> for cross-user lookups (gated by SAR in the REST
-	// handler). Without this registration the apiserver pre-rejects the
-	// selector before the handler ever sees it.
-	sessionUserIDConversion := func(label, value string) (string, string, error) {
-		switch label {
-		case "status.userUID", "metadata.name", "metadata.namespace":
-			return label, value, nil
-		default:
-			return "", "", nil
-		}
-	}
-
+	// Sessions are listed by callers using status.userUID=<uid> for
+	// cross-user lookups (gated by SAR in the REST handler). Without this
+	// registration the apiserver pre-rejects the selector before the handler
+	// ever sees it.
 	_ = s.AddFieldLabelConversionFunc(
 		schema.GroupVersionKind{
 			Group:   milov1alpha1.SchemeGroupVersion.Group,
 			Version: milov1alpha1.SchemeGroupVersion.Version,
 			Kind:    "Session",
 		},
-		sessionUserIDConversion,
-	)
-
-	_ = s.AddFieldLabelConversionFunc(
-		schema.GroupVersionKind{
-			Group:   milov1alpha1.SchemeGroupVersion.Group,
-			Version: milov1alpha1.SchemeGroupVersion.Version,
-			Kind:    "UserIdentity",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.userUID", "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", nil
+			}
 		},
-		sessionUserIDConversion,
 	)
 }


### PR DESCRIPTION
## Summary

The aggregated apiserver pre-validates List field selectors against the default conversion function, which only accepts `metadata.name` and `metadata.namespace`. Any other label is rejected with `"<label>" is not a known field selector: only "metadata.name", "metadata.namespace"` *before* the request reaches our REST handler.

The Session handler (added in #69) consumes `status.userUID=<uid>` for cross-user lookups (SAR-gated against milo), but the requests never make it that far — observed live in staging when fraud-operator started calling `kubectl get sessions --field-selector=status.userUID=<uid>` (see retry loop in fraud-operator logs):

```
failed to list Sessions for user "370790442461041217": "status.userUID" is not a known field selector: only "metadata.name", "metadata.namespace"
```

## Fix

Register a `FieldLabelConversionFunc` for the `Session` GVK in `pkg/apis/identity/scheme.go` that passes `status.userUID` through (plus `metadata.name`/`metadata.namespace`). Mirrors the existing `MachineAccountKey` registration in the same `Install` function. SAR enforcement is unchanged — the REST handler still rejects unauthorized cross-user lookups.

`UserIdentity` has the same selector consumer in its REST handler, but no caller uses it today, so leaving it out — easy to add the same 13-line block when there is a caller.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/apis/... ./internal/apiserver/...` clean
- [ ] Once merged + rolled to staging, confirm fraud-operator's Sessions list returns rather than the "not a known field selector" 400 (visible in `kubectl -n fraud-system logs deploy/fraud-controller-manager`)

## Related

- datum-cloud/auth-provider-zitadel#69 — added the Session REST handler with the `status.userUID` selector consumer
- datum-cloud/fraud#32 — fraud-operator caller that surfaced the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)