### PR TITLE
fix(apiserver): re-register status.userUID field selector for UserIdentity

### DIFF
--- a/pkg/apis/identity/scheme.go
+++ b/pkg/apis/identity/scheme.go
@@ -31,23 +31,34 @@ func Install(s *runtime.Scheme) {
 		},
 	)
 
-	// Sessions are listed by callers using status.userUID=<uid> for
-	// cross-user lookups (gated by SAR in the REST handler). Without this
-	// registration the apiserver pre-rejects the selector before the handler
-	// ever sees it.
+	// Sessions and UserIdentities are listed by callers using
+	// status.userUID=<uid> for cross-user lookups (gated by SAR in the REST
+	// handler). Without this registration the apiserver pre-rejects the
+	// selector before the handler ever sees it.
+	userScopedSelector := func(label, value string) (string, string, error) {
+		switch label {
+		case "status.userUID", "metadata.name", "metadata.namespace":
+			return label, value, nil
+		default:
+			return "", "", nil
+		}
+	}
+
 	_ = s.AddFieldLabelConversionFunc(
 		schema.GroupVersionKind{
 			Group:   milov1alpha1.SchemeGroupVersion.Group,
 			Version: milov1alpha1.SchemeGroupVersion.Version,
 			Kind:    "Session",
 		},
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "status.userUID", "metadata.name", "metadata.namespace":
-				return label, value, nil
-			default:
-				return "", "", nil
-			}
+		userScopedSelector,
+	)
+
+	_ = s.AddFieldLabelConversionFunc(
+		schema.GroupVersionKind{
+			Group:   milov1alpha1.SchemeGroupVersion.Group,
+			Version: milov1alpha1.SchemeGroupVersion.Version,
+			Kind:    "UserIdentity",
 		},
+		userScopedSelector,
 	)
 }


### PR DESCRIPTION
## Summary

Re-adds the `status.userUID` field-selector scheme registration for `UserIdentity` that was dropped in aa926e7 ("only Session is needed today").

The cross-user identity-lookup code path in `internal/apiserver/identity/useridentities/rest.go:64-92` (added in #69 / 969f6de) is wired up correctly — caller passes `?fieldSelector=status.userUID=<targetUID>`, handler runs a Milo SAR check, and on success calls `ListIDPLinks(ctx, targetUID)`. But without the corresponding `AddFieldLabelConversionFunc` registration, the generic apiserver rejects the request before the handler runs:

> "status.userUID" is not a known field selector: only "metadata.name", "metadata.namespace"

The fix is the same one-time registration we already do for `Session`. Refactored the conversion func into a shared closure so the two kinds stay in lock-step.

**Why this is needed:** the staff portal user detail page wants to show a target user's social login providers (Google/GitHub/Email) — read-only, populated via the same `status.userUID=<uid>` selector path that fraud-operator uses for sessions. Today that selector is rejected for `UserIdentity` so the staff portal falls back to listing the *staff user's* identities, not the viewed user's.

## Test plan
- [ ] Build (`go build ./...`) — clean
- [ ] Verify against staging staff portal: target user's IDPs render in the read-only Account Identities card
- [ ] Confirm self-only behavior unchanged (no regression on `/profile/setting` for staff or cloud-portal)
- [ ] Confirm 403 still returned when caller lacks `get` on `iam.miloapis.com/users/<targetUID>` in milo