### PR TITLE
feat: mirror MaxMind tracking-token from Zitadel metadata to User

### DIFF
--- a/internal/apiserver/identity/sessions/rest.go
+++ b/internal/apiserver/identity/sessions/rest.go
@@ -49,6 +49,34 @@ var _ rest.SingularNameProvider = &REST{}
 
 var sessionsGR = schema.GroupResource{Group: milov1alpha1.SchemeGroupVersion.Group, Resource: "sessions"}
 
+// metadataAnnotationKeys lists the Zitadel session metadata keys that are
+// exposed on the milo Session via ObjectMeta.Annotations along with the
+// destination annotation key. Add new entries here when a metadata key needs
+// to be visible to platform consumers (e.g. the fraud service).
+var metadataAnnotationKeys = map[string]string{
+	"maxmind/tracking-token": "iam.miloapis.com/maxmind-tracking-token",
+}
+
+// sessionAnnotations builds the ObjectMeta.Annotations for a milo Session
+// from the Zitadel session metadata, filtered through the metadataAnnotationKeys
+// allowlist. Returns nil when no recognised entries are present so we don't
+// stamp empty annotations onto every response.
+func sessionAnnotations(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	var out map[string]string
+	for src, dst := range metadataAnnotationKeys {
+		if v, ok := metadata[src]; ok && v != "" {
+			if out == nil {
+				out = make(map[string]string, len(metadataAnnotationKeys))
+			}
+			out[dst] = v
+		}
+	}
+	return out
+}
+
 func (r *REST) NamespaceScoped() bool   { return false }
 func (r *REST) New() runtime.Object     { return &milov1alpha1.Session{} }
 func (r *REST) NewList() runtime.Object { return &milov1alpha1.SessionList{} }
@@ -113,6 +141,7 @@ func (r *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              s.ID,
 				CreationTimestamp: metav1.NewTime(now),
+				Annotations:       sessionAnnotations(s.Metadata),
 			},
 			Status: milov1alpha1.SessionStatus{
 				UserUID:       uid,
@@ -148,8 +177,11 @@ func (r *REST) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runt
 	}
 	klog.V(3).InfoS("Got session", "name", name, "owner", s.UserID)
 	return &milov1alpha1.Session{
-		TypeMeta:   metav1.TypeMeta{Kind: "Session", APIVersion: milov1alpha1.SchemeGroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Name: s.ID},
+		TypeMeta: metav1.TypeMeta{Kind: "Session", APIVersion: milov1alpha1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        s.ID,
+			Annotations: sessionAnnotations(s.Metadata),
+		},
 		Status: milov1alpha1.SessionStatus{
 			UserUID:       s.UserID,
 			Provider:      "zitadel",

--- a/internal/apiserver/identity/sessions/rest_test.go
+++ b/internal/apiserver/identity/sessions/rest_test.go
@@ -1,0 +1,53 @@
+package sessions
+
+import "testing"
+
+func TestSessionAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{
+			name: "nil metadata returns nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty metadata returns nil",
+			in:   map[string]string{},
+			want: nil,
+		},
+		{
+			name: "only allowlisted keys are surfaced",
+			in: map[string]string{
+				"maxmind/tracking-token": "tok-abc",
+				"unrelated/key":          "ignored",
+			},
+			want: map[string]string{
+				"iam.miloapis.com/maxmind-tracking-token": "tok-abc",
+			},
+		},
+		{
+			name: "empty values are dropped",
+			in: map[string]string{
+				"maxmind/tracking-token": "",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sessionAnnotations(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("annotation %q = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/pkg/zitadel/api.go
+++ b/pkg/zitadel/api.go
@@ -29,6 +29,12 @@ type Session struct {
 	CreatedAt     time.Time
 	LastUpdated   *time.Time
 	UserAgent     string
+	// Metadata is the arbitrary key/value bag Zitadel exposes on a session.
+	// Today it carries the MaxMind device-tracking token (key
+	// "maxmind/tracking-token"); the apiserver mirrors selected entries onto
+	// the milo Session as annotations so they can be read by downstream
+	// consumers like the fraud service.
+	Metadata map[string]string
 }
 
 // IDPLink represents an identity provider link for a user.

--- a/pkg/zitadel/sdk_client.go
+++ b/pkg/zitadel/sdk_client.go
@@ -145,6 +145,13 @@ func (c *SDKClient) mapZitadelSession(s *sessionv2.Session) Session {
 		t := cd.AsTime()
 		lastUpdated = &t
 	}
+	var metadata map[string]string
+	if md := s.GetMetadata(); len(md) > 0 {
+		metadata = make(map[string]string, len(md))
+		for k, v := range md {
+			metadata[k] = string(v)
+		}
+	}
 	return Session{
 		ID:            s.GetId(),
 		UserID:        s.GetFactors().GetUser().GetId(),
@@ -153,6 +160,7 @@ func (c *SDKClient) mapZitadelSession(s *sessionv2.Session) Session {
 		CreatedAt:     toTime(s.GetCreationDate()),
 		LastUpdated:   lastUpdated,
 		UserAgent:     extractUserAgentString(zeUA),
+		Metadata:      metadata,
 	}
 }
 


### PR DESCRIPTION
## Merge order (1 of 5)

This is the **first** PR to merge in a cross-repo rollout enabling MaxMind device fingerprinting in the signup fraud check.

1. **auth-provider-zitadel** (this PR) — surface Zitadel session metadata as milo Session annotations
2. fraud — [datum-cloud/fraud#39](https://github.com/datum-cloud/fraud/pull/39)
3. datum.net — [datum-cloud/datum.net#1289](https://github.com/datum-cloud/datum.net/pull/1289)
4. auth-ui — [datum-cloud/auth-ui#77](https://github.com/datum-cloud/auth-ui/pull/77)
5. infra — [datum-cloud/infra#2412](https://github.com/datum-cloud/infra/pull/2412)

Each PR is a backward-compatible no-op in isolation; the order just avoids a window where downstream consumers expect data the upstream isn't yet producing.

---

## Summary

Surface Zitadel session metadata on the milo \`Session\` resource as standard \`ObjectMeta.Annotations\` so per-session signals (today: the MaxMind device-tracking token captured by the browser at signup) can be read by downstream consumers like the fraud service without leaking onto the long-lived User resource.

**Why session-scoped:** device fingerprinting is intrinsically per-device — a user can have many sessions across many devices, and the token captured during a specific signup belongs to that session, not the user identity. Surfacing it on \`Session\` keeps the signal aligned with the resource it describes.

Key features/changes:
- Add \`Metadata map[string]string\` to the internal \`zitadel.Session\` struct; \`mapZitadelSession\` copies the metadata map from the Zitadel session via \`s.GetMetadata()\`
- In the sessions REST handler (\`internal/apiserver/identity/sessions/rest.go\`), project an allowlisted subset of metadata entries onto \`ObjectMeta.Annotations\` on the milo Session. Today the allowlist maps \`maxmind/tracking-token\` to \`iam.miloapis.com/maxmind-tracking-token\`; extending it is a single-line entry in the \`metadataAnnotationKeys\` map
- \`sessionAnnotations\` returns nil when no allowlisted entries are present so unrelated sessions aren't stamped with empty annotation maps
- Unit tests cover the four paths (nil/empty input, allowlisted key present, unrelated keys filtered, empty value dropped)

**No milo CRD changes.** No new actions-server flags, no Zitadel SDK lookup, no User annotations.

## Test plan

- [ ] \`go test ./internal/apiserver/identity/sessions/... ./pkg/zitadel/...\` passes.
- [ ] Once auth-ui rolls out, register a test user and inspect \`kubectl get session.identity.miloapis.com <id> -o yaml\` — confirm \`metadata.annotations[\"iam.miloapis.com/maxmind-tracking-token\"]\` is set.
- [ ] Confirm Sessions without the metadata key don't carry the annotation.