### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
+      registry-organization: milo-os
       image-name: auth-provider-zitadel
       platforms: linux/amd64,linux/arm64
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,9 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.13.1
     with:
-      bundle-name: ghcr.io/datum-cloud/auth-provider-zitadel-kustomize
+      bundle-name: ghcr.io/milo-os/zitadel-provider-kustomize
       bundle-path: config
       image-overlays: config/base
-      image-name: ghcr.io/datum-cloud/auth-provider-zitadel
+      image-name: ghcr.io/milo-os/zitadel-provider
       debug: true
     secrets: inherit

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,7 +18,7 @@ env:
   TASK_X_REMOTE_TASKFILES: 1
   # Test infrastructure configuration
   TEST_INFRA_CLUSTER_NAME: test-infra
-  IMAGE_NAME: ghcr.io/datum-cloud/auth-provider-zitadel
+  IMAGE_NAME: ghcr.io/milo-os/zitadel-provider
   IMAGE_TAG: dev
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 .PHONY: install-external-crds
 install-external-crds: ## Install external CRDs from milo repository.
 	@echo "Installing MachineAccount CRDs from milo repository..."
-	@kubectl apply -k https://github.com/datum-cloud/milo/config/crd/bases/iam?ref=v0.2.0 || { \
+	@kubectl apply -k https://github.com/milo-os/milo/config/crd/bases/iam?ref=v0.2.0 || { \
 		echo "ERROR: Failed to install MachineAccount CRDs from milo repository."; \
 		exit 1; \
 	}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ machine accounts.
 ## Overview
 
 This project provides the authentication foundation for the [Milo business
-operating system](https://github.com/datum-cloud/milo), which uses Kubernetes
+operating system](https://github.com/milo-os/milo), which uses Kubernetes
 APIServer patterns to manage business entities for product-led B2B companies.
 The auth provider integrates Milo's business APIs with Zitadel's identity and
 access management platform to handle complex authentication scenarios like:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,7 +15,7 @@ includes:
 vars:
   WAIT_TIMEOUT: "20m"
   TOOL_DIR: "{{.USER_WORKING_DIR}}/bin"
-  IMAGE_NAME: "ghcr.io/datum-cloud/auth-provider-zitadel"
+  IMAGE_NAME: "ghcr.io/milo-os/zitadel-provider"
   IMAGE_TAG: "dev"
   TEST_INFRA_CLUSTER_NAME: "test-infra"
   TEST_INFRA_REPO_REF: "v0.6.0"
@@ -160,11 +160,11 @@ tasks:
         set -e
         echo "Installing IAM and Infrastructure CRDs..."
         task test-infra:kubectl -- apply \
-          -k https://github.com/datum-cloud/milo/config/crd/bases/iam
+          -k https://github.com/milo-os/milo/config/crd/bases/iam
         task test-infra:kubectl -- apply \
-          -k https://github.com/datum-cloud/milo/config/crd/bases/infrastructure?ref=v0.21.0
+          -k https://github.com/milo-os/milo/config/crd/bases/infrastructure?ref=v0.21.0
         task test-infra:kubectl -- apply \
-          -k https://github.com/datum-cloud/milo/config/crd/bases/resourcemanager?ref=v0.21.0
+          -k https://github.com/milo-os/milo/config/crd/bases/resourcemanager?ref=v0.21.0
         echo "Milo CRDs installed."
 
   ci:port-forward:

--- a/config/base/services/apiserver/deployment.yaml
+++ b/config/base/services/apiserver/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: apiserver
-          image: ghcr.io/datum-cloud/auth-provider-zitadel:latest
+          image: ghcr.io/milo-os/zitadel-provider:latest
           args:
             - apiserver
             - --secure-port=8443

--- a/config/base/services/authn-webhook/authn-webhook.yaml
+++ b/config/base/services/authn-webhook/authn-webhook.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: authn-webhook
-          image: ghcr.io/datum-cloud/auth-provider-zitadel:latest
+          image: ghcr.io/milo-os/zitadel-provider:latest
           imagePullPolicy: IfNotPresent
           args:
             - authn-webhook

--- a/config/base/services/authn-webhook/kustomization.yaml
+++ b/config/base/services/authn-webhook/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - authn-webhook.yaml
 - authn-webhook-service.yaml
 images:
-- name: ghcr.io/datum-cloud/auth-provider-zitadel
+- name: ghcr.io/milo-os/zitadel-provider
   newTag: latest

--- a/config/base/services/controller-manager/kustomization.yaml
+++ b/config/base/services/controller-manager/kustomization.yaml
@@ -4,6 +4,6 @@ resources:
 - manager.yaml
 - metrics-service.yaml
 images:
-- name: ghcr.io/datum-cloud/auth-provider-zitadel
-  newName: ghcr.io/datum-cloud/auth-provider-zitadel
+- name: ghcr.io/milo-os/zitadel-provider
+  newName: ghcr.io/milo-os/zitadel-provider
   newTag: latest

--- a/config/base/services/controller-manager/manager.yaml
+++ b/config/base/services/controller-manager/manager.yaml
@@ -86,7 +86,7 @@ spec:
           - --server-config=$(ZITADEL_CONTROLLER_MANAGER_CONFIG_PATH)
           # Configure which kubeconfig to use for the core control plane.
           - --core-control-plane-kubeconfig=$(CORE_CONTROL_PLANE_KUBECONFIG_PATH)
-        image: ghcr.io/datum-cloud/auth-provider-zitadel:latest
+        image: ghcr.io/milo-os/zitadel-provider:latest
         name: controller-manager
         env:
         # Leader election environment variables

--- a/config/dependencies/zitadel/helmrelease.yaml
+++ b/config/dependencies/zitadel/helmrelease.yaml
@@ -158,7 +158,7 @@ spec:
     # Runs co-located with Zitadel so TLS is not needed for the loopback address.
     extraContainers:
       - name: zitadel-actions-server
-        image: ghcr.io/datum-cloud/auth-provider-zitadel:dev
+        image: ghcr.io/milo-os/zitadel-provider:dev
         imagePullPolicy: Never
         args:
           - actions-server

--- a/config/overlays/ci/kustomization.yaml
+++ b/config/overlays/ci/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Override the image tag to use the locally-built dev image.
 # This affects all three services since they share the same image name.
 images:
-  - name: ghcr.io/datum-cloud/auth-provider-zitadel
+  - name: ghcr.io/milo-os/zitadel-provider
     newTag: dev
 
 patches:

--- a/docs/identity-api-tests.md
+++ b/docs/identity-api-tests.md
@@ -274,5 +274,5 @@ These tests can be integrated into CI/CD pipelines:
 ## Related Documentation
 
 - [Architecture Overview](./architecture.md)
-- [Milo Identity API Documentation](https://github.com/datum-cloud/milo/blob/main/docs/api/identity.md)
+- [Milo Identity API Documentation](https://github.com/milo-os/milo/blob/main/docs/api/identity.md)
 - [Zitadel Integration](https://zitadel.com/docs)


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.