### PR TITLE
feat(actions): add suspicious login detection with email notification

### DIFF
--- a/cmd/actionsserver/http_server_cmd.go
+++ b/cmd/actionsserver/http_server_cmd.go
@@ -1,14 +1,20 @@
 package actionsserver
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/zitadel/zitadel/pkg/actions"
 	"go.miloapis.com/auth-provider-zitadel/internal/config"
 	"go.miloapis.com/auth-provider-zitadel/internal/httpactionsserver"
+	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
 	signature "go.miloapis.com/auth-provider-zitadel/pkg/zitadel-actions/signature"
 	iamiamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	notificationv1alpha1 "go.miloapis.com/milo/pkg/apis/notification/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -22,6 +28,13 @@ import (
 func NewActionsServerCommand(globalConfig *config.GlobalConfig) *cobra.Command {
 	log := logf.Log.WithName("actions-server-cmd")
 	cfg := httpactionsserver.NewServerConfig()
+
+	var (
+		zitadelIssuer               string
+		zitadelAPI                  string
+		zitadelKeyPath              string
+		defaultMachineKeyExpiration time.Duration
+	)
 
 	cmd := &cobra.Command{
 		Use:   "actions-server",
@@ -49,6 +62,7 @@ If a TLS certificate and key are provided, the server will start in HTTPS mode. 
 			log.Info("Building Kubernetes scheme with IAM APIs")
 			scheme := runtime.NewScheme()
 			utilruntime.Must(iamiamv1alpha1.AddToScheme(scheme))
+			utilruntime.Must(notificationv1alpha1.AddToScheme(scheme))
 			log.V(1).Info("Successfully built Kubernetes scheme")
 
 			log.Info("Creating Kubernetes client")
@@ -74,9 +88,40 @@ If a TLS certificate and key are provided, the server will start in HTTPS mode. 
 				validateSignatureFunc = actions.ValidatePayload
 			}
 
+			// Initialize the Zitadel SDK client. This is intentionally
+			// non-fatal: the actions server runs as a sidecar in the Zitadel
+			// pod, and blocking startup on reaching Zitadel deadlocks the pod.
+			// The zitadel Service only routes to a Ready pod, and the pod is
+			// not Ready until this container is up — so if we exit here, the
+			// Service never gets an endpoint and this container can never
+			// reach Zitadel. Start anyway and retry in the background.
+			zitadelSDKClient, err := createZitadelClient(
+				cmd.Context(),
+				zitadelIssuer,
+				zitadelAPI,
+				zitadelKeyPath,
+				defaultMachineKeyExpiration,
+			)
+			switch {
+			case err != nil:
+				log.Error(err, "Failed to initialize Zitadel SDK client; starting without session endpoints and retrying in background")
+			case zitadelSDKClient != nil:
+				log.V(1).Info("Successfully initialized Zitadel SDK client")
+			default:
+				log.Info("Zitadel SDK client configuration not provided; session endpoints will be unavailable")
+			}
+
 			// Start the server
 			log.Info("Starting HTTP actions server")
-			svr := httpactionsserver.NewServer(cfg, k8sClient, validateSignatureFunc)
+			svr := httpactionsserver.NewServer(cfg, k8sClient, validateSignatureFunc, zitadelSDKClient)
+
+			// If the SDK was configured but unreachable at startup, keep
+			// retrying in the background and install the client once Zitadel
+			// becomes available.
+			if err != nil {
+				go retryZitadelClient(cmd.Context(), log, svr, zitadelIssuer, zitadelAPI, zitadelKeyPath, defaultMachineKeyExpiration)
+			}
+
 			return svr.Start()
 		},
 	}
@@ -88,7 +133,96 @@ If a TLS certificate and key are provided, the server will start in HTTPS mode. 
 	cmd.Flags().BoolVar(&cfg.DisableHTTP2, "disable-http2", cfg.DisableHTTP2, "Disable HTTP/2 when serving with TLS (forces http/1.1)")
 	cmd.Flags().StringVar(&cfg.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file.")
 	cmd.Flags().StringVar(&cfg.SigningKey, "signing-key", "", "Signing key for validating Zitadel webhook signatures. Provided by Zitadel when creating the Webhook Target.")
-	cmd.Flags().BoolVar(&cfg.DisableSignatureValidation, "disable-signature-validation", cfg.DisableSignatureValidation, "Disable signature validation of Zitadel webhook payloadsb")
+	cmd.Flags().BoolVar(&cfg.DisableSignatureValidation, "disable-signature-validation", cfg.DisableSignatureValidation, "Disable signature validation of Zitadel webhook payloads")
+
+	// Notification flags
+	cmd.Flags().StringVar(&cfg.SuspiciousLoginEmailTemplate, "suspicious-login-email-template", cfg.SuspiciousLoginEmailTemplate, "Name of the EmailTemplate cluster resource used for suspicious login notifications")
+	cmd.Flags().StringVar(&cfg.NotificationNamespace, "notification-namespace", cfg.NotificationNamespace, "Namespace in which Email resources are created")
+
+	// GraphQL Gateway flags
+	cmd.Flags().StringVar(&cfg.GraphQLGatewayURL, "graphql-gateway-url", cfg.GraphQLGatewayURL, "GraphQL gateway endpoint used for IP geolocation (empty disables geolocation)")
+	cmd.Flags().StringVar(&cfg.GraphQLGatewayCACertFile, "graphql-gateway-ca-cert", cfg.GraphQLGatewayCACertFile, "Path to PEM CA cert used to verify the gateway TLS certificate")
+
+	// Zitadel flags
+	cmd.Flags().StringVar(&zitadelIssuer, "zitadel-issuer", "", "Zitadel issuer URL (fallback: ZITADEL_ISSUER env)")
+	cmd.Flags().StringVar(&zitadelAPI, "zitadel-api", "", "Zitadel API base URL (fallback: ZITADEL_API env)")
+	cmd.Flags().StringVar(&zitadelKeyPath, "zitadel-key", "", "Path to Zitadel machine account key (fallback: ZITADEL_KEY_PATH env)")
+	cmd.Flags().DurationVar(&defaultMachineKeyExpiration, "zitadel-default-machine-key-expiration", 10*365*24*time.Hour, "The default duration for machine account keys (defaults to 10 years)")
 
 	return cmd
+}
+
+func createZitadelClient(
+	ctx context.Context,
+	issuer string,
+	domain string,
+	keyPath string,
+	defaultExpiration time.Duration,
+) (zitadel.API, error) {
+	// Only read the key path from env if the flag is empty
+	if keyPath == "" {
+		keyPath = os.Getenv("ZITADEL_KEY_PATH")
+	}
+	if keyPath == "" {
+		keyPath = os.Getenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH")
+	}
+
+	// Domain and Issuer must be provided via flags (do not fallback to environment)
+	if issuer == "" || domain == "" || keyPath == "" {
+		return nil, nil
+	}
+
+	return zitadel.NewSDK(ctx, zitadel.SDKConfig{
+		Issuer:                      issuer,
+		Domain:                      domain,
+		KeyPath:                     keyPath,
+		DefaultMachineKeyExpiration: defaultExpiration,
+	})
+}
+
+// retryZitadelClient keeps attempting to initialize the Zitadel SDK client with
+// exponential backoff until it succeeds (or the context is cancelled), then
+// installs it on the server. This lets the server start and become Ready while
+// Zitadel is still coming up, recovering from a same-pod startup race or a
+// transient Zitadel outage without crash-looping.
+func retryZitadelClient(
+	ctx context.Context,
+	log logr.Logger,
+	svr *httpactionsserver.Server,
+	issuer string,
+	domain string,
+	keyPath string,
+	defaultExpiration time.Duration,
+) {
+	const (
+		initialBackoff = 1 * time.Second
+		maxBackoff     = 1 * time.Minute
+	)
+
+	backoff := initialBackoff
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		client, err := createZitadelClient(ctx, issuer, domain, keyPath, defaultExpiration)
+		if err != nil {
+			log.Error(err, "Retrying Zitadel SDK client initialization", "retryIn", backoff.String())
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+		if client == nil {
+			// Configuration is incomplete; nothing to retry.
+			return
+		}
+
+		svr.SetZitadelClient(client)
+		log.Info("Successfully initialized Zitadel SDK client (background retry)")
+		return
+	}
 }

--- a/cmd/actionsserver/http_server_cmd_test.go
+++ b/cmd/actionsserver/http_server_cmd_test.go
@@ -1,0 +1,87 @@
+package actionsserver
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCreateZitadelClient_Validation(t *testing.T) {
+	// Clean up environment variables to ensure test isolation
+	originalKeyPath := os.Getenv("ZITADEL_KEY_PATH")
+	originalMachineKeyPath := os.Getenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH")
+	originalAPI := os.Getenv("ZITADEL_API")
+	originalIssuer := os.Getenv("ZITADEL_ISSUER")
+
+	defer func() {
+		_ = os.Setenv("ZITADEL_KEY_PATH", originalKeyPath)
+		_ = os.Setenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH", originalMachineKeyPath)
+		_ = os.Setenv("ZITADEL_API", originalAPI)
+		_ = os.Setenv("ZITADEL_ISSUER", originalIssuer)
+	}()
+
+	_ = os.Setenv("ZITADEL_KEY_PATH", "")
+	_ = os.Setenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH", "")
+	_ = os.Setenv("ZITADEL_API", "env-api.zitadel.cloud")
+	_ = os.Setenv("ZITADEL_ISSUER", "https://env-api.zitadel.cloud")
+
+	ctx := context.Background()
+
+	t.Run("returns nil, nil if issuer is empty", func(t *testing.T) {
+		client, err := createZitadelClient(ctx, "", "domain.com", "key.json", 1*time.Hour)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected client to be nil")
+		}
+	})
+
+	t.Run("returns nil, nil if domain is empty", func(t *testing.T) {
+		client, err := createZitadelClient(ctx, "https://issuer.com", "", "key.json", 1*time.Hour)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected client to be nil")
+		}
+	})
+
+	t.Run("returns nil, nil if key path is empty (both flag and env)", func(t *testing.T) {
+		_ = os.Setenv("ZITADEL_KEY_PATH", "")
+		_ = os.Setenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH", "")
+		client, err := createZitadelClient(ctx, "https://issuer.com", "domain.com", "", 1*time.Hour)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected client to be nil")
+		}
+	})
+
+	t.Run("uses key path from ZITADEL_KEY_PATH env if flag is empty", func(t *testing.T) {
+		_ = os.Setenv("ZITADEL_KEY_PATH", "env-key.json")
+		_ = os.Setenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH", "")
+		// This should try to instantiate NewSDK and fail with "open env-key.json: no such file or directory"
+		_, err := createZitadelClient(ctx, "https://issuer.com", "domain.com", "", 1*time.Hour)
+		if err == nil {
+			t.Error("expected error due to missing file, got nil")
+		} else if !strings.Contains(err.Error(), "env-key.json") && !strings.Contains(err.Error(), "no such file") {
+			t.Errorf("expected error about env-key.json, got: %v", err)
+		}
+	})
+
+	t.Run("uses key path from ZITADEL_MACHINE_ACCOUNT_KEY_PATH env if ZITADEL_KEY_PATH is empty", func(t *testing.T) {
+		_ = os.Setenv("ZITADEL_KEY_PATH", "")
+		_ = os.Setenv("ZITADEL_MACHINE_ACCOUNT_KEY_PATH", "machine-env-key.json")
+		// This should try to instantiate NewSDK and fail with "open machine-env-key.json: no such file or directory"
+		_, err := createZitadelClient(ctx, "https://issuer.com", "domain.com", "", 1*time.Hour)
+		if err == nil {
+			t.Error("expected error due to missing file, got nil")
+		} else if !strings.Contains(err.Error(), "machine-env-key.json") && !strings.Contains(err.Error(), "no such file") {
+			t.Errorf("expected error about machine-env-key.json, got: %v", err)
+		}
+	})
+}

--- a/config/dependencies/zitadel/helmrelease.yaml
+++ b/config/dependencies/zitadel/helmrelease.yaml
@@ -148,10 +148,20 @@ spec:
       - name: nginx-proxy-config
         configMap:
           name: nginx-proxy-config
+      - name: zitadel-admin-sa
+        secret:
+          secretName: zitadel-admin-sa
+          # optional: machinekeyWriter creates this secret after Zitadel is up;
+          # marking it optional breaks the circular startup dependency while still
+          # letting the kubelet populate the volume once the secret appears.
+          optional: true
 
     extraVolumeMounts:
       - name: zitadel-tls
         mountPath: /etc/zitadel/tls
+        readOnly: true
+      - name: zitadel-admin-sa
+        mountPath: /etc/zitadel/auth
         readOnly: true
 
     # actions-server sidecar: mirrors the production pattern from datum-infra.
@@ -164,6 +174,13 @@ spec:
           - actions-server
           - --addr=127.0.0.1:8888
           - --disable-signature-validation=true
+          - --zitadel-issuer=https://zitadel.zitadel-system.svc.cluster.local:443
+          - --zitadel-api=zitadel.zitadel-system.svc.cluster.local:443
+          - --zitadel-key=/etc/zitadel/auth/sa.json
+        volumeMounts:
+          - name: zitadel-admin-sa
+            mountPath: /etc/zitadel/auth
+            readOnly: true
 
       # nginx reverse proxy: terminates TLS on port 9443 (the service targetPort)
       # and routes /ui/v2/login to the login UI service, everything else to Zitadel.

--- a/docs/components/suspicious-login-detection.md
+++ b/docs/components/suspicious-login-detection.md
@@ -1,0 +1,30 @@
+# Suspicious Login Detection
+
+When a user signs in, Zitadel fires an `oidc_session.added` event to the actions server. The server compares the new session's IP address, user-agent, and browser fingerprint against the user's full session history. If any of those values have never been seen before, the login is flagged as suspicious and the user receives an email notification.
+
+## How it works
+
+1. Zitadel delivers the `oidc_session.added` event to `POST /v1/actions/session-added`.
+2. The handler reads the current session's IP, user-agent description, and fingerprint ID from the event payload.
+3. It calls the Zitadel API to list all existing sessions for that user, then removes the current session from the list.
+4. If the IP, user-agent, or fingerprint has not appeared in any previous session, `isSuspiciousLogin` returns true.
+5. `handleSuspiciousLogin` resolves a human-readable location (via `geolocateIP` on the GraphQL gateway) and parses the user-agent into browser/OS strings (via `parseUserAgent` on the GraphQL gateway). Both calls fall back gracefully if the gateway is unreachable.
+6. An `Email` resource (`notification.miloapis.com/v1alpha1`) is created in the `milo-system` namespace, referencing the `emailtemplates.notification.miloapis.com-usersuspiciousemailtemplate` template. The notification system delivers it to the user.
+
+## Zitadel configuration
+
+This component requires **Zitadel Actions v2** to be configured with:
+
+- **Target** — type `REST Webhook`, endpoint `https://localhost:8888/v1/actions/session-added`
+- **Action** — type `Events`, condition `oidc_session.added`, referencing the target above
+
+The endpoint uses `localhost` because the actions server runs as a sidecar container in the same Zitadel pod and only listens on `127.0.0.1:8888`.
+
+## Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| Zitadel API (machine account) | List sessions for a user |
+| GraphQL gateway (`graphql-gateway.graphql-gateway.svc.cluster.local:4000`) | Geolocation and user-agent parsing |
+| `datum-control-plane-trust-bundle` | CA cert for TLS to the GraphQL gateway |
+| `notification.miloapis.com` Email CRD | Deliver the alert email |

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -2,18 +2,23 @@ package httpactionsserver
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
+	"sync"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
 	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -28,6 +33,19 @@ type ServerConfig struct {
 	Kubeconfig                 string
 	SigningKey                 string
 	DisableSignatureValidation bool
+	// SuspiciousLoginEmailTemplate is the name of the EmailTemplate cluster resource
+	// used to notify users of suspicious login activity.
+	SuspiciousLoginEmailTemplate string
+	// NotificationNamespace is the namespace in which Email resources are created.
+	NotificationNamespace string
+	// GraphQLGatewayURL is the endpoint of the internal GraphQL gateway used
+	// for IP geolocation and user-agent parsing.
+	// When empty, those lookups are skipped and fallbacks are used instead.
+	GraphQLGatewayURL string
+	// GraphQLGatewayCACertFile is the path to a PEM-encoded CA certificate
+	// used to verify the gateway's TLS certificate. When empty the system
+	// cert pool is used (sufficient if the CA is already trusted by the OS).
+	GraphQLGatewayCACertFile string
 }
 
 type ValidateSignatureFunc func(payload []byte, header string, signingKey string) error
@@ -35,8 +53,12 @@ type ValidateSignatureFunc func(payload []byte, header string, signingKey string
 // NewServerConfig returns a config initialised with sensible defaults.
 func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
-		Addr:                       ":8082",
-		DisableSignatureValidation: false,
+		Addr:                         ":8082",
+		DisableSignatureValidation:   false,
+		SuspiciousLoginEmailTemplate: "emailtemplates.notification.miloapis.com-usersuspiciousemailtemplate",
+		NotificationNamespace:        "milo-system",
+		GraphQLGatewayURL:            "https://graphql-gateway.graphql-gateway.svc.cluster.local:4000/graphql",
+		GraphQLGatewayCACertFile:     "/etc/ssl/certs/datum-ca.crt",
 	}
 }
 
@@ -45,16 +67,76 @@ type Server struct {
 	config            *ServerConfig
 	k8sClient         client.Client
 	validateSignature ValidateSignatureFunc
+
+	// httpClient is used for outbound HTTP calls (e.g. geolocation lookups).
+	httpClient *http.Client
+
+	// mu guards zitadelClient, which may be installed asynchronously by a
+	// background initializer after the server has already started.
+	mu            sync.RWMutex
+	zitadelClient zitadel.API
+}
+
+// SetZitadelClient atomically installs the Zitadel SDK client. It is safe for
+// concurrent use and is called by the background initializer once Zitadel
+// becomes reachable.
+func (s *Server) SetZitadelClient(c zitadel.API) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.zitadelClient = c
+}
+
+// zitadelAPI returns the current Zitadel SDK client, or nil if it has not been
+// initialized yet.
+func (s *Server) zitadelAPI() zitadel.API {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.zitadelClient
 }
 
 // NewServer creates a new HTTP actions server instance
-func NewServer(cfg *ServerConfig, k8sClient client.Client, validateSignatureFunc ValidateSignatureFunc) *Server {
+func NewServer(cfg *ServerConfig, k8sClient client.Client, validateSignatureFunc ValidateSignatureFunc, zitadelClient zitadel.API) *Server {
 	log := logf.Log.WithName("httpactionsserver")
 	log.Info("Creating new HTTP actions server", "addr", cfg.Addr, "tlsEnabled", cfg.CertFile != "" && cfg.KeyFile != "")
 	return &Server{
 		config:            cfg,
 		k8sClient:         k8sClient,
 		validateSignature: validateSignatureFunc,
+		zitadelClient:     zitadelClient,
+		httpClient:        buildHTTPClient(log, cfg.GraphQLGatewayCACertFile),
+	}
+}
+
+// buildHTTPClient creates an http.Client that trusts the cluster CA cert at
+// caCertFile (if the file exists) in addition to the system cert pool. When
+// the file is absent the default system pool is used, which is correct for
+// environments where the CA is already trusted at the OS level.
+func buildHTTPClient(log interface{ Info(string, ...any) }, caCertFile string) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if caCertFile != "" {
+		pem, err := os.ReadFile(caCertFile)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Info("Could not read gateway CA cert file; using system cert pool", "file", caCertFile, "err", err)
+			}
+		} else {
+			pool, err := x509.SystemCertPool()
+			if err != nil {
+				pool = x509.NewCertPool()
+			}
+			if pool.AppendCertsFromPEM(pem) {
+				transport.TLSClientConfig = &tls.Config{RootCAs: pool}
+				log.Info("Loaded gateway CA cert", "file", caCertFile)
+			} else {
+				log.Info("gateway CA cert file contained no valid PEM blocks; using system cert pool", "file", caCertFile)
+			}
+		}
+	}
+
+	return &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
 	}
 }
 
@@ -98,6 +180,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/v1/actions/create-user-account", s.createUserAccountHandler)
 	mux.HandleFunc("/v1/actions/customize-jwt", s.customizeJwtHandler)
 	mux.HandleFunc("/v1/actions/idp-intent-succeeded", s.idpIntentSucceededHandler)
+	mux.HandleFunc("/v1/actions/session-added", s.sessionAddedHandler)
 
 	srv := &http.Server{
 		Addr:    s.config.Addr,

--- a/internal/httpactionsserver/server_test.go
+++ b/internal/httpactionsserver/server_test.go
@@ -1,0 +1,774 @@
+package httpactionsserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	notificationv1alpha1 "go.miloapis.com/milo/pkg/apis/notification/v1alpha1"
+
+	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
+)
+
+type mockZitadelAPI struct {
+	listSessionsFunc func(ctx context.Context, userID string) ([]zitadel.Session, error)
+}
+
+func (m *mockZitadelAPI) ListSessions(ctx context.Context, userID string) ([]zitadel.Session, error) {
+	if m.listSessionsFunc != nil {
+		return m.listSessionsFunc(ctx, userID)
+	}
+	return nil, nil
+}
+func (m *mockZitadelAPI) GetSession(ctx context.Context, sessionID string) (*zitadel.Session, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) DeleteSession(ctx context.Context, userID, sessionID string) error {
+	return nil
+}
+func (m *mockZitadelAPI) ListIDPLinks(ctx context.Context, userID string) ([]zitadel.IDPLink, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) CreateOrganization(ctx context.Context, name string) (string, error) {
+	return "", nil
+}
+func (m *mockZitadelAPI) CreateOrganizationWithID(ctx context.Context, name, customOrgID string) (string, error) {
+	return "", nil
+}
+func (m *mockZitadelAPI) DeleteOrganization(ctx context.Context, orgID string) error { return nil }
+func (m *mockZitadelAPI) GetOrganization(ctx context.Context, orgID string) (*zitadel.Organization, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) GetUserByID(ctx context.Context, userID string) (*zitadel.User, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) GetMachineUserByUsername(ctx context.Context, orgID, username string) (*zitadel.User, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) AddMachineUserInOrganization(ctx context.Context, orgID, userID, username, displayName string) (string, error) {
+	return "", nil
+}
+func (m *mockZitadelAPI) DeleteUser(ctx context.Context, userID string) error            { return nil }
+func (m *mockZitadelAPI) DeactivateUser(ctx context.Context, orgID, userID string) error { return nil }
+func (m *mockZitadelAPI) ReactivateUser(ctx context.Context, orgID, userID string) error { return nil }
+func (m *mockZitadelAPI) ListMachineAccountsInOrganization(ctx context.Context, orgID string) ([]*zitadel.User, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) AddMachineKeyInOrganization(ctx context.Context, orgID, userID string, publicKey []byte, expirationDate *time.Time) (string, []byte, error) {
+	return "", nil, nil
+}
+func (m *mockZitadelAPI) ListMachineKeysInOrganization(ctx context.Context, orgID, userID string) ([]*zitadel.MachineKey, error) {
+	return nil, nil
+}
+func (m *mockZitadelAPI) RemoveMachineKeyInOrganization(ctx context.Context, orgID, userID, keyID string) error {
+	return nil
+}
+
+// logEntry captures a single structured log record emitted during a test.
+type logEntry struct {
+	msg string
+	kv  map[string]any
+}
+
+// captureSink is a minimal logr.LogSink that records Info records so tests can
+// assert on structured fields instead of scraping stdout.
+type captureSink struct {
+	entries *[]logEntry
+}
+
+func (s captureSink) Init(logr.RuntimeInfo) {}
+func (s captureSink) Enabled(int) bool      { return true }
+func (s captureSink) Info(_ int, msg string, kvs ...any) {
+	kv := make(map[string]any, len(kvs)/2)
+	for i := 0; i+1 < len(kvs); i += 2 {
+		key, _ := kvs[i].(string)
+		kv[key] = kvs[i+1]
+	}
+	*s.entries = append(*s.entries, logEntry{msg: msg, kv: kv})
+}
+func (s captureSink) Error(_ error, msg string, kvs ...any) { s.Info(0, msg, kvs...) }
+func (s captureSink) WithValues(...any) logr.LogSink        { return s }
+func (s captureSink) WithName(string) logr.LogSink          { return s }
+
+// newTestScheme builds a runtime.Scheme that includes all API groups used by
+// the handler under test.
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = iamv1alpha1.AddToScheme(s)
+	_ = notificationv1alpha1.AddToScheme(s)
+	return s
+}
+
+// findEntry returns the first captured entry with the given message, or nil.
+func findEntry(entries []logEntry, msg string) *logEntry {
+	for i := range entries {
+		if entries[i].msg == msg {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+func TestSessionAddedHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		reqPayload     sessionAddedRequest
+		mockSessions   []zitadel.Session
+		wantSuspicious bool
+		wantDevice     string
+		wantBrowser    string
+	}{
+		{
+			name: "First login ever (no previous sessions)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:          "1.1.1.1",
+						Description: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now(),
+				},
+			},
+			wantSuspicious: false,
+		},
+		{
+			name: "Same IP and UA (not suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:          "1.1.1.1",
+						Description: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        "sess-prev",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				},
+			},
+			wantSuspicious: false,
+		},
+		{
+			name: "Different IP (suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:          "2.2.2.2",
+						Description: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "2.2.2.2",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        "sess-prev",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				},
+			},
+			wantSuspicious: true,
+			wantDevice:     "Mac",
+			wantBrowser:    "Chrome",
+		},
+		{
+			name: "Different Browser (suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:          "1.1.1.1",
+						Description: "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) Firefox/100.0",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) Firefox/100.0",
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        "sess-prev",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				},
+			},
+			wantSuspicious: true,
+			wantDevice:     "iPhone",
+			wantBrowser:    "Firefox",
+		},
+		{
+			name: "Mobile Firefox and oidc_session.added (suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:            "1.1.1.1",
+						FingerprintID: "031d5d16-1258-4681-afb8-579fbc3871bb",
+						Description:   "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) Firefox/100.0",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) Firefox/100.0",
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        "sess-prev",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				},
+			},
+			wantSuspicious: true,
+			wantDevice:     "iPhone",
+			wantBrowser:    "Firefox",
+		},
+		{
+			name: "Different Fingerprint ID but same IP and UA (suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:            "1.1.1.1",
+						FingerprintID: "new-fingerprint",
+						Description:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:            "sess-prev",
+					UserID:        "user-1",
+					IP:            "1.1.1.1",
+					UserAgent:     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					FingerprintID: "old-fingerprint",
+					CreatedAt:     time.Now().Add(-1 * time.Hour),
+				},
+			},
+			wantSuspicious: true,
+			wantDevice:     "Mac",
+			wantBrowser:    "Chrome",
+		},
+		{
+			// Regression: the most-recent *other* session has a rotated
+			// fingerprint, but the current fingerprint reappears in an older
+			// session — a returning device, so this must NOT be flagged.
+			name: "Returning fingerprint seen in older session (not suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:            "1.1.1.1",
+						FingerprintID: "known-fingerprint",
+						Description:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:            "sess-curr",
+					UserID:        "user-1",
+					IP:            "1.1.1.1",
+					UserAgent:     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					FingerprintID: "known-fingerprint",
+					CreatedAt:     time.Now(),
+				},
+				{
+					ID:            "sess-recent",
+					UserID:        "user-1",
+					IP:            "1.1.1.1",
+					UserAgent:     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					FingerprintID: "rotated-fingerprint",
+					CreatedAt:     time.Now().Add(-1 * time.Hour),
+				},
+				{
+					ID:            "sess-old",
+					UserID:        "user-1",
+					IP:            "1.1.1.1",
+					UserAgent:     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					FingerprintID: "known-fingerprint",
+					CreatedAt:     time.Now().Add(-24 * time.Hour),
+				},
+			},
+		},
+		{
+			name: "IP and UA match different past sessions in history (not suspicious)",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:          "1.1.1.1",
+						Description: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:        "sess-curr",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        "sess-recent",
+					UserID:    "user-1",
+					IP:        "2.2.2.2",
+					UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				},
+				{
+					ID:        "sess-old",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/120.0",
+					CreatedAt: time.Now().Add(-2 * time.Hour),
+				},
+			},
+			wantSuspicious: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockZitadelAPI{
+				listSessionsFunc: func(ctx context.Context, userID string) ([]zitadel.Session, error) {
+					return tt.mockSessions, nil
+				},
+			}
+
+			server := &Server{
+				// SuspiciousLoginEmailTemplate is intentionally empty so the
+				// email path is skipped and no k8s User lookup is needed.
+				config:            &ServerConfig{},
+				validateSignature: func(payload []byte, header string, signingKey string) error { return nil },
+				zitadelClient:     mockClient,
+				k8sClient:         fake.NewClientBuilder().WithScheme(newTestScheme()).Build(),
+			}
+
+			payloadBytes, err := json.Marshal(tt.reqPayload)
+			if err != nil {
+				t.Fatalf("failed to marshal request payload: %v", err)
+			}
+
+			var entries []logEntry
+			ctx := logf.IntoContext(context.Background(), logr.New(captureSink{entries: &entries}))
+			req := httptest.NewRequest(http.MethodPost, "/v1/actions/session-added", bytes.NewReader(payloadBytes)).WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			server.sessionAddedHandler(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("expected status OK, got %d. Body: %s", w.Code, w.Body.String())
+			}
+
+			susp := findEntry(entries, "Suspicious login detected")
+			isSuspicious := susp != nil
+			if isSuspicious != tt.wantSuspicious {
+				t.Errorf("expected suspicious to be %v, got %v. Captured entries: %+v", tt.wantSuspicious, isSuspicious, entries)
+			}
+
+			if tt.wantSuspicious {
+				if susp.kv["device"] != tt.wantDevice {
+					t.Errorf("expected device %q, got %v", tt.wantDevice, susp.kv["device"])
+				}
+				if susp.kv["browser"] != tt.wantBrowser {
+					t.Errorf("expected browser %q, got %v", tt.wantBrowser, susp.kv["browser"])
+				}
+			}
+		})
+	}
+}
+
+func TestSessionAddedHandlerErrorPaths(t *testing.T) {
+	const validBody = `{"event_type":"oidc_session.added","aggregateID":"sess-curr","event_payload":{"userID":"user-1"}}`
+
+	okSig := func(payload []byte, header, signingKey string) error { return nil }
+	failSig := func(payload []byte, header, signingKey string) error { return errors.New("bad signature") }
+
+	mock := &mockZitadelAPI{
+		listSessionsFunc: func(ctx context.Context, userID string) ([]zitadel.Session, error) {
+			return nil, nil
+		},
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		sig        ValidateSignatureFunc
+		client     zitadel.API
+		wantStatus int
+	}{
+		{
+			name:       "wrong method returns 405",
+			method:     http.MethodGet,
+			body:       validBody,
+			sig:        okSig,
+			client:     mock,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "signature failure returns 401",
+			method:     http.MethodPost,
+			body:       validBody,
+			sig:        failSig,
+			client:     mock,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "invalid json returns 400",
+			method:     http.MethodPost,
+			body:       "{not-json",
+			sig:        okSig,
+			client:     mock,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "unsupported event type returns 400",
+			method:     http.MethodPost,
+			body:       `{"event_type":"user.added","event_payload":{"userID":"user-1"}}`,
+			sig:        okSig,
+			client:     mock,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing userID returns 400",
+			method:     http.MethodPost,
+			body:       `{"event_type":"oidc_session.added"}`,
+			sig:        okSig,
+			client:     mock,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "nil zitadel client returns 503",
+			method:     http.MethodPost,
+			body:       validBody,
+			sig:        okSig,
+			client:     nil,
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &Server{
+				config:            &ServerConfig{},
+				validateSignature: tt.sig,
+				zitadelClient:     tt.client,
+				k8sClient:         fake.NewClientBuilder().WithScheme(newTestScheme()).Build(),
+			}
+
+			req := httptest.NewRequest(tt.method, "/v1/actions/session-added", bytes.NewReader([]byte(tt.body)))
+			w := httptest.NewRecorder()
+
+			server.sessionAddedHandler(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestSendSuspiciousLoginEmail(t *testing.T) {
+	const (
+		userID    = "362926680773230861"
+		namespace = "milo-system"
+		template  = "emailtemplates.notification.miloapis.com-usersuspiciousemailtemplate"
+	)
+
+	user := &iamv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: userID},
+		Spec: iamv1alpha1.UserSpec{
+			GivenName:  "Jane",
+			FamilyName: "Doe",
+			Email:      "jane.doe@example.com",
+		},
+	}
+
+	t.Run("skips when template not configured", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
+		s := &Server{
+			config:    &ServerConfig{NotificationNamespace: namespace},
+			k8sClient: k8s,
+		}
+		var entries []logEntry
+		log := logr.New(captureSink{entries: &entries})
+		if err := sendSuspiciousLoginEmail(context.Background(), log, s, userID, "2026-06-05T12:00:00Z", "1.2.3.4", "Mac", "Safari", "Brazil"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if findEntry(entries, "Suspicious login email template not configured; skipping notification") == nil {
+			t.Error("expected skip log entry, got none")
+		}
+		// Confirm no Email resource was created.
+		emails := &notificationv1alpha1.EmailList{}
+		if err := k8s.List(context.Background(), emails); err != nil {
+			t.Fatalf("list emails: %v", err)
+		}
+		if len(emails.Items) != 0 {
+			t.Errorf("expected 0 emails, got %d", len(emails.Items))
+		}
+	})
+
+	t.Run("returns error when user not found", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
+		s := &Server{
+			config:    &ServerConfig{SuspiciousLoginEmailTemplate: template, NotificationNamespace: namespace},
+			k8sClient: k8s,
+		}
+		log := logr.New(captureSink{entries: &[]logEntry{}})
+		err := sendSuspiciousLoginEmail(context.Background(), log, s, "nonexistent-user", "2026-06-05T12:00:00Z", "1.2.3.4", "Mac", "Safari", "Brazil")
+		if err == nil {
+			t.Error("expected error for missing user, got nil")
+		}
+	})
+
+	t.Run("creates Email resource with correct fields", func(t *testing.T) {
+		k8s := fake.NewClientBuilder().
+			WithScheme(newTestScheme()).
+			WithObjects(user).
+			Build()
+		s := &Server{
+			config:    &ServerConfig{SuspiciousLoginEmailTemplate: template, NotificationNamespace: namespace},
+			k8sClient: k8s,
+		}
+		var entries []logEntry
+		log := logr.New(captureSink{entries: &entries})
+
+		if err := sendSuspiciousLoginEmail(context.Background(), log, s, userID, "2026-06-05T12:00:00Z", "186.158.228.76", "Mac", "Safari", "Brazil"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		emails := &notificationv1alpha1.EmailList{}
+		if err := k8s.List(context.Background(), emails); err != nil {
+			t.Fatalf("list emails: %v", err)
+		}
+		if len(emails.Items) != 1 {
+			t.Fatalf("expected 1 Email resource, got %d", len(emails.Items))
+		}
+		e := emails.Items[0]
+
+		if e.Namespace != namespace {
+			t.Errorf("expected namespace %q, got %q", namespace, e.Namespace)
+		}
+		if e.Spec.TemplateRef.Name != template {
+			t.Errorf("expected template %q, got %q", template, e.Spec.TemplateRef.Name)
+		}
+		if e.Spec.Recipient.UserRef.Name != userID {
+			t.Errorf("expected userRef.name %q, got %q", userID, e.Spec.Recipient.UserRef.Name)
+		}
+		if e.Spec.Priority != notificationv1alpha1.EmailPriorityHigh {
+			t.Errorf("expected priority high, got %q", e.Spec.Priority)
+		}
+
+		vars := make(map[string]string, len(e.Spec.Variables))
+		for _, v := range e.Spec.Variables {
+			vars[v.Name] = v.Value
+		}
+		checks := map[string]string{
+			"UserName":  "Jane Doe",
+			"Email":     "jane.doe@example.com",
+			"IpAddress": "186.158.228.76",
+			"Location":  "Brazil",
+			"Browser":   "Safari",
+			"Device":    "Mac",
+		}
+		for k, want := range checks {
+			if got := vars[k]; got != want {
+				t.Errorf("variable %q: expected %q, got %q", k, want, got)
+			}
+		}
+		if vars["SignInTime"] == "" {
+			t.Error("expected non-empty SignInTime variable")
+		}
+		if findEntry(entries, "Suspicious login notification email created") == nil {
+			t.Error("expected success log entry, got none")
+		}
+	})
+}
+
+func TestParseDeviceAndBrowser(t *testing.T) {
+	tests := []struct {
+		ua          string
+		wantDevice  string
+		wantBrowser string
+	}{
+		{
+			ua:          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+			wantDevice:  "Windows PC",
+			wantBrowser: "Chrome",
+		},
+		{
+			ua:          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+			wantDevice:  "Mac",
+			wantBrowser: "Safari",
+		},
+		{
+			ua:          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+			wantDevice:  "iPhone",
+			wantBrowser: "Safari",
+		},
+		{
+			ua:          "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+			wantDevice:  "Android Device",
+			wantBrowser: "Chrome",
+		},
+		{
+			ua:          "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/120.0",
+			wantDevice:  "Linux PC",
+			wantBrowser: "Firefox",
+		},
+		{
+			ua:          "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/605.1.15",
+			wantDevice:  "iPad",
+			wantBrowser: "Firefox",
+		},
+		{
+			ua:          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+			wantDevice:  "Mac",
+			wantBrowser: "Edge",
+		},
+		{
+			ua:          "Unknown user agent",
+			wantDevice:  "Unknown Device",
+			wantBrowser: "Unknown Browser",
+		},
+		{
+			ua:          "Safari, 26.3.1, ,  Apple, Macintosh, , WebKit, 605.1.15, , Mac OS, 10.15.7, ",
+			wantDevice:  "Mac",
+			wantBrowser: "Safari",
+		},
+		{
+			ua:          "Chrome, 148.0.7778.166, , mobile, Apple, iPhone, , WebKit, 605.1.15, , iOS, 26.1.0, ",
+			wantDevice:  "iPhone",
+			wantBrowser: "Chrome",
+		},
+	}
+
+	for _, tt := range tests {
+		gotDevice := parseDevice(tt.ua)
+		gotBrowser := parseBrowser(tt.ua)
+		if gotDevice != tt.wantDevice {
+			t.Errorf("parseDevice(%q) = %q, want %q", tt.ua, gotDevice, tt.wantDevice)
+		}
+		if gotBrowser != tt.wantBrowser {
+			t.Errorf("parseBrowser(%q) = %q, want %q", tt.ua, gotBrowser, tt.wantBrowser)
+		}
+	}
+}

--- a/internal/httpactionsserver/session_added.go
+++ b/internal/httpactionsserver/session_added.go
@@ -1,0 +1,379 @@
+package httpactionsserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	notificationv1alpha1 "go.miloapis.com/milo/pkg/apis/notification/v1alpha1"
+
+	"go.miloapis.com/auth-provider-zitadel/pkg/gateway"
+	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
+)
+
+type userAgent struct {
+	IP            string `json:"ip"`
+	FingerprintID string `json:"fingerprint_id"`
+	Description   string `json:"description"`
+}
+
+type sessionAddedRequest struct {
+	AggregateID   string `json:"aggregateID"`
+	AggregateType string `json:"aggregateType"`
+	ResourceOwner string `json:"resourceOwner"`
+	InstanceID    string `json:"instanceID"`
+	Version       string `json:"version"`
+	Sequence      int    `json:"sequence"`
+	EventType     string `json:"event_type"`
+	CreatedAt     string `json:"created_at"`
+	UserID        string `json:"userID"`
+	EventPayload  struct {
+		UserID    string     `json:"userID"`
+		SessionID string     `json:"sessionID"`
+		UserAgent *userAgent `json:"userAgent"`
+	} `json:"event_payload"`
+}
+
+// sessionAddedHandler handles the session.added event to detect suspicious logins.
+func (s *Server) sessionAddedHandler(w http.ResponseWriter, r *http.Request) {
+	log := logf.FromContext(r.Context()).WithName("sessionAddedHandler")
+	log.Info("Handling session-added request", "method", r.Method, "remoteAddr", r.RemoteAddr)
+
+	if r.Method != http.MethodPost {
+		log.Error(nil, "Method not allowed", "method", r.Method)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Error(err, "Failed to read request body")
+		http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if err := s.validateSignature(bodyBytes, r.Header.Get("Zitadel-Signature"), s.config.SigningKey); err != nil {
+		log.Error(err, "Signature validation failed")
+		http.Error(w, fmt.Sprintf("signature validation failed: %v", err), http.StatusUnauthorized)
+		return
+	}
+	log.V(1).Info("Request signature validated successfully")
+
+	var req sessionAddedRequest
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		log.Error(err, "Failed to unmarshal request body")
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	log.V(1).Info("Request body unmarshaled successfully")
+
+	if req.EventType != "oidc_session.added" {
+		log.Error(nil, "Unsupported event type", "eventType", req.EventType)
+		http.Error(w, fmt.Sprintf("unsupported event type: %s", req.EventType), http.StatusBadRequest)
+		return
+	}
+
+	userID := req.EventPayload.UserID
+	if userID == "" {
+		log.Error(nil, "User ID not found in payload")
+		http.Error(w, "userID not found in payload", http.StatusBadRequest)
+		return
+	}
+
+	zClient := s.zitadelAPI()
+	if zClient == nil {
+		log.Error(nil, "Zitadel SDK client not configured, cannot retrieve session history")
+		http.Error(w, "zitadel sdk client not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var currentIP string
+	var currentUserAgent string
+	var currentFingerprint string
+	ua := req.EventPayload.UserAgent
+	if ua != nil {
+		currentIP = ua.IP
+		currentUserAgent = ua.Description
+		currentFingerprint = ua.FingerprintID
+	}
+
+	log.Info("Checking sessions for user", "userId", userID)
+	sessions, err := zClient.ListSessions(r.Context(), userID)
+	if err != nil {
+		log.Error(err, "Failed to list sessions from Zitadel", "userId", userID)
+		http.Error(w, fmt.Sprintf("failed to list sessions: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	sessionID := req.EventPayload.SessionID
+	if sessionID == "" {
+		sessionID = req.AggregateID
+	}
+
+	previousSessions := getPreviousSessions(sessions, sessionID)
+	if len(previousSessions) > 0 {
+		if isSuspiciousLogin(log, previousSessions, currentIP, currentUserAgent, currentFingerprint) {
+			handleSuspiciousLogin(r.Context(), log, s, userID, req.CreatedAt, currentIP, currentUserAgent)
+		} else {
+			log.Info("Login is not suspicious", "userId", userID)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("success"))
+}
+
+// getPreviousSessions filters the list of sessions to return all sessions other than the current one.
+func getPreviousSessions(sessions []zitadel.Session, currentSessionID string) []zitadel.Session {
+	previous := make([]zitadel.Session, 0, len(sessions))
+	for i := range sessions {
+		if sessions[i].ID == currentSessionID {
+			continue
+		}
+		previous = append(previous, sessions[i])
+	}
+	return previous
+}
+
+// isSuspiciousLogin evaluates the current login details against the history of previous sessions.
+func isSuspiciousLogin(log logr.Logger, previousSessions []zitadel.Session, currentIP, currentUserAgent, currentFingerprint string) bool {
+	if len(previousSessions) == 0 {
+		return false
+	}
+
+	ipSeen := false
+	userAgentSeen := false
+	fingerprintSeen := false
+
+	for _, sess := range previousSessions {
+		if sess.IP == currentIP {
+			ipSeen = true
+		}
+		if sess.UserAgent == currentUserAgent {
+			userAgentSeen = true
+		}
+		if currentFingerprint != "" && sess.FingerprintID == currentFingerprint {
+			fingerprintSeen = true
+		}
+	}
+
+	isNewIP := currentIP != "" && !ipSeen
+	isNewUserAgent := currentUserAgent != "" && !userAgentSeen
+	isNewFingerprint := currentFingerprint != "" && !fingerprintSeen
+
+	log.Info("Comparing current login against session history",
+		"currentIP", currentIP, "ipSeen", ipSeen, "isNewIP", isNewIP,
+		"currentUserAgent", currentUserAgent, "userAgentSeen", userAgentSeen, "isNewUserAgent", isNewUserAgent,
+		"currentFingerprint", currentFingerprint, "fingerprintSeen", fingerprintSeen, "isNewFingerprint", isNewFingerprint,
+	)
+
+	return isNewIP || isNewUserAgent || isNewFingerprint
+}
+
+// handleSuspiciousLogin logs the suspicious login and sends a notification email to the user.
+func handleSuspiciousLogin(ctx context.Context, log logr.Logger, s *Server, userID, signInTime, ip, userAgent string) {
+	device, browser := resolveUserAgent(ctx, log, s, userAgent)
+	location := resolveLocation(ctx, log, s, ip)
+
+	log.Info("Suspicious login detected", "userId", userID, "ip", ip, "device", device, "browser", browser, "location", location)
+
+	if err := sendSuspiciousLoginEmail(ctx, log, s, userID, signInTime, ip, device, browser, location); err != nil {
+		log.Error(err, "Failed to send suspicious login notification email", "userId", userID)
+	}
+}
+
+// sendSuspiciousLoginEmail looks up the User resource by Zitadel userID and
+// creates an Email resource that the notification system delivers.
+func sendSuspiciousLoginEmail(ctx context.Context, log logr.Logger, s *Server, userID, signInTime, ip, device, browser, location string) error {
+	if s.config.SuspiciousLoginEmailTemplate == "" {
+		log.Info("Suspicious login email template not configured; skipping notification")
+		return nil
+	}
+
+	// Fetch the User resource — its name is the Zitadel aggregate ID.
+	user := &iamv1alpha1.User{}
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{Name: userID}, user); err != nil {
+		return fmt.Errorf("failed to get user %q: %w", userID, err)
+	}
+
+	displayName := strings.TrimSpace(user.Spec.GivenName + " " + user.Spec.FamilyName)
+	if displayName == "" {
+		displayName = user.Spec.Email
+	}
+
+	// Parse signInTime into a human-readable format; fall back to the raw string.
+	signInDisplay := signInTime
+	if t, err := time.Parse(time.RFC3339Nano, signInTime); err == nil {
+		signInDisplay = t.UTC().Format("Jan 2, 2006 at 15:04 UTC")
+	}
+
+	email := &notificationv1alpha1.Email{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Email",
+			APIVersion: "notification.miloapis.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("suspicious-login-%s", uuid.NewUUID()),
+			Namespace: s.config.NotificationNamespace,
+		},
+		Spec: notificationv1alpha1.EmailSpec{
+			TemplateRef: notificationv1alpha1.TemplateReference{
+				Name: s.config.SuspiciousLoginEmailTemplate,
+			},
+			Recipient: notificationv1alpha1.EmailRecipient{
+				UserRef: notificationv1alpha1.EmailUserReference{
+					Name: user.Name,
+				},
+			},
+			Variables: []notificationv1alpha1.EmailVariable{
+				{Name: "UserName", Value: displayName},
+				{Name: "Email", Value: user.Spec.Email},
+				{Name: "Location", Value: location},
+				{Name: "SignInTime", Value: signInDisplay},
+				{Name: "Browser", Value: browser},
+				{Name: "Device", Value: device},
+				{Name: "IpAddress", Value: ip},
+			},
+			Priority: notificationv1alpha1.EmailPriorityHigh,
+		},
+	}
+
+	if err := s.k8sClient.Create(ctx, email); err != nil {
+		return fmt.Errorf("failed to create suspicious login Email resource: %w", err)
+	}
+
+	log.Info("Suspicious login notification email created", "userId", userID, "emailName", email.Name)
+	return nil
+}
+
+// resolveLocation returns a human-readable location string for ip by querying
+// the GraphQL gateway. If the gateway URL is not configured, the IP is
+// unreachable, or no record is found, it falls back to the raw IP address so
+// the email is always sent with something meaningful.
+func resolveLocation(ctx context.Context, log logr.Logger, s *Server, ip string) string {
+	if s.config.GraphQLGatewayURL == "" || ip == "" {
+		return ip
+	}
+
+	geo, err := gateway.LookupIP(ctx, s.httpClient, s.config.GraphQLGatewayURL, ip)
+	if err != nil {
+		log.Error(err, "Failed to resolve geolocation; falling back to raw IP", "ip", ip)
+		return ip
+	}
+	if geo == nil || geo.Formatted == "" {
+		return ip
+	}
+
+	log.V(1).Info("Resolved geolocation", "ip", ip, "location", geo.Formatted)
+	return geo.Formatted
+}
+
+// resolveUserAgent queries the GraphQL gateway to parse ua into device and
+// browser strings. Falls back to the local parseDevice/parseBrowser helpers
+// when the gateway URL is unconfigured, ua is empty, or the call fails.
+func resolveUserAgent(ctx context.Context, log logr.Logger, s *Server, ua string) (device, browser string) {
+	if s.config.GraphQLGatewayURL != "" && ua != "" {
+		parsed, err := gateway.ParseUserAgent(ctx, s.httpClient, s.config.GraphQLGatewayURL, ua)
+		if err != nil {
+			log.Error(err, "Failed to parse user agent via gateway; using local fallback", "userAgent", ua)
+		} else if parsed != nil {
+			log.V(1).Info("Parsed user agent via gateway", "browser", parsed.Browser, "os", parsed.OS)
+			return parsed.OS, parsed.Browser
+		}
+	}
+	return parseDevice(ua), parseBrowser(ua)
+}
+
+func parseDevice(ua string) string {
+	uaLower := strings.ToLower(ua)
+	if strings.Contains(uaLower, ",") {
+		parts := strings.Split(uaLower, ",")
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			switch trimmed {
+			case "iphone":
+				return "iPhone"
+			case "ipad":
+				return "iPad"
+			case "android":
+				return "Android Device"
+			case "macintosh", "mac os", "macos", "mac os x":
+				return "Mac"
+			case "windows":
+				return "Windows PC"
+			case "linux":
+				return "Linux PC"
+			}
+		}
+	}
+
+	if strings.Contains(uaLower, "iphone") {
+		return "iPhone"
+	}
+	if strings.Contains(uaLower, "ipad") {
+		return "iPad"
+	}
+	if strings.Contains(uaLower, "android") {
+		return "Android Device"
+	}
+	if strings.Contains(uaLower, "macintosh") || strings.Contains(uaLower, "mac os") || strings.Contains(uaLower, "macos") {
+		return "Mac"
+	}
+	if strings.Contains(uaLower, "windows") {
+		return "Windows PC"
+	}
+	if strings.Contains(uaLower, "linux") {
+		return "Linux PC"
+	}
+	return "Unknown Device"
+}
+
+func parseBrowser(ua string) string {
+	uaLower := strings.ToLower(ua)
+	if strings.Contains(uaLower, ",") {
+		parts := strings.Split(uaLower, ",")
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			switch trimmed {
+			case "firefox", "fxios":
+				return "Firefox"
+			case "edge", "edg":
+				return "Edge"
+			case "opera", "opr":
+				return "Opera"
+			case "chrome", "crios":
+				return "Chrome"
+			case "safari":
+				return "Safari"
+			}
+		}
+	}
+
+	if strings.Contains(uaLower, "firefox/") || strings.Contains(uaLower, "fxios/") {
+		return "Firefox"
+	}
+	if strings.Contains(uaLower, "edg/") || strings.Contains(uaLower, "edge/") {
+		return "Edge"
+	}
+	if strings.Contains(uaLower, "opr/") || strings.Contains(uaLower, "opera/") {
+		return "Opera"
+	}
+	if strings.Contains(uaLower, "chrome/") || strings.Contains(uaLower, "crios/") {
+		return "Chrome"
+	}
+	if strings.Contains(uaLower, "safari/") {
+		return "Safari"
+	}
+	return "Unknown Browser"
+}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -1,0 +1,111 @@
+// Package gateway provides clients for queries exposed by the internal
+// GraphQL gateway (graphql-gateway.graphql-gateway.svc.cluster.local:4000).
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// GeoLocation holds the resolved location for an IP address.
+type GeoLocation struct {
+	City        string `json:"city"`
+	Country     string `json:"country"`
+	CountryCode string `json:"countryCode"`
+	Formatted   string `json:"formatted"`
+}
+
+// ParsedUserAgent holds the parsed components of a User-Agent string.
+type ParsedUserAgent struct {
+	Browser   string `json:"browser"`
+	OS        string `json:"os"`
+	Formatted string `json:"formatted"`
+}
+
+// LookupIP queries the gateway for the city/country associated with ip.
+// Returns nil (no error) when the gateway has no record (e.g. private IPs).
+// Errors only on network or protocol failures.
+func LookupIP(ctx context.Context, client *http.Client, gatewayURL, ip string) (*GeoLocation, error) {
+	const query = `query GeolocateIP($ip: String!) {
+  geolocateIP(ip: $ip) { city country countryCode formatted }
+}`
+	var resp struct {
+		Data struct {
+			GeolocateIP *GeoLocation `json:"geolocateIP"`
+		} `json:"data"`
+	}
+	if err := do(ctx, client, gatewayURL, query, map[string]any{"ip": ip}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data.GeolocateIP, nil
+}
+
+// ParseUserAgent queries the gateway to parse a raw User-Agent string into
+// browser, OS, and a human-readable formatted string.
+// Returns nil (no error) when the gateway cannot parse the value.
+func ParseUserAgent(ctx context.Context, client *http.Client, gatewayURL, userAgent string) (*ParsedUserAgent, error) {
+	const query = `query ParseUserAgent($ua: String!) {
+  parseUserAgent(userAgent: $ua) { browser os formatted }
+}`
+	var resp struct {
+		Data struct {
+			ParseUserAgent *ParsedUserAgent `json:"parseUserAgent"`
+		} `json:"data"`
+	}
+	if err := do(ctx, client, gatewayURL, query, map[string]any{"ua": userAgent}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data.ParseUserAgent, nil
+}
+
+// do executes a GraphQL query against the gateway and decodes the response
+// into out. It is the shared transport used by all public functions in this
+// package.
+func do(ctx context.Context, client *http.Client, url, query string, variables map[string]any, out any) error {
+	body, err := json.Marshal(struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}{Query: query, Variables: variables})
+	if err != nil {
+		return fmt.Errorf("gateway: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("gateway: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("gateway: http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("gateway: unexpected status %d", resp.StatusCode)
+	}
+
+	// Decode into a wrapper that surfaces GraphQL-level errors.
+	var envelope struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	// Decode twice: once into the error envelope, once into the caller's out.
+	// We decode into a raw json.RawMessage first to avoid consuming the body.
+	var raw json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return fmt.Errorf("gateway: decode response: %w", err)
+	}
+	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Errors) > 0 {
+		return fmt.Errorf("gateway: %s", envelope.Errors[0].Message)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("gateway: decode data: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Summary

When a user signs in, Zitadel fires an oidc_session.added webhook to the actions server sidecar. This PR implements a handler that compares the new session's IP, user-agent, and browser fingerprint against the user's full session history. If any of those values have never been seen before, the login is flagged as suspicious and the user receives an email via the notification.miloapis.com Email CRD.

Key behaviors:

- Detection compares all three signals (IP, user-agent, fingerprint) across full session history — a match on any one is sufficient to clear the flag
- Geolocation and user-agent parsing are delegated to the internal GraphQL gateway (geolocateIP, parseUserAgent), with local fallbacks if the gateway is unreachable
- Zitadel SDK init is non-fatal at startup to avoid a same-pod sidecar deadlock; the client is installed via a background retry goroutine
- The gateway HTTP client loads the cluster CA cert at startup (datum-control-plane-trust-bundle) so TLS to the gateway is trusted without skipping verification

Related to:
- https://github.com/datum-cloud/tmp_datum-cloud_enhancements_729_Extend-notification-_b9bd25d4/issues/1#issuecomment-4622257008