### PR TITLE
fix: retry idp intent avatar sync when user is missing

### DIFF
--- a/cmd/actionsserver/http_server_cmd.go
+++ b/cmd/actionsserver/http_server_cmd.go
@@ -143,6 +143,10 @@ If a TLS certificate and key are provided, the server will start in HTTPS mode. 
 	cmd.Flags().StringVar(&cfg.GraphQLGatewayURL, "graphql-gateway-url", cfg.GraphQLGatewayURL, "GraphQL gateway endpoint used for IP geolocation (empty disables geolocation)")
 	cmd.Flags().StringVar(&cfg.GraphQLGatewayCACertFile, "graphql-gateway-ca-cert", cfg.GraphQLGatewayCACertFile, "Path to PEM CA cert used to verify the gateway TLS certificate")
 
+	// IDP intent avatar sync flags
+	cmd.Flags().IntVar(&cfg.IdpIntentUserLookupAttempts, "idp-intent-user-lookup-attempts", cfg.IdpIntentUserLookupAttempts, "Retry count when idpintent.succeeded arrives before the Milo User exists")
+	cmd.Flags().DurationVar(&cfg.IdpIntentUserLookupBaseWait, "idp-intent-user-lookup-base-wait", cfg.IdpIntentUserLookupBaseWait, "Initial backoff between idp-intent user lookup retries")
+
 	// Zitadel flags
 	cmd.Flags().StringVar(&zitadelIssuer, "zitadel-issuer", "", "Zitadel issuer URL (fallback: ZITADEL_ISSUER env)")
 	cmd.Flags().StringVar(&zitadelAPI, "zitadel-api", "", "Zitadel API base URL (fallback: ZITADEL_API env)")

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -1,6 +1,7 @@
 package httpactionsserver
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
@@ -459,12 +461,22 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Update user avatar URL and last login provider
+	userID := miloUserIDFromIdpIntent(req)
+	if userID == "" {
+		log.Error(nil, "User ID not found in idpintent.succeeded payload")
+		http.Error(w, "userID not found in payload", http.StatusBadRequest)
+		return
+	}
+
 	ctx := r.Context()
-	current := &iammiloapiscomv1alpha1.User{}
-	if err := s.k8sClient.Get(ctx, client.ObjectKey{Name: req.EventPayload.UserID}, current); err != nil {
-		log.Error(err, "Failed to get User resource", "userId", req.EventPayload.UserID)
-		http.Error(w, "user not found", http.StatusNotFound)
+	current, err := s.getUserWithRetry(ctx, userID)
+	if err != nil {
+		log.Error(err, "Failed to get User resource", "userId", userID)
+		if apierrors.IsNotFound(err) {
+			http.Error(w, "user not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to get user", http.StatusInternalServerError)
 		return
 	}
 	original := current.DeepCopy()
@@ -479,9 +491,39 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	log.Info("Processed idpintent.succeeded", "idpProvider", idpProvider, "avatarURL", avatarURL, "userId", req.EventPayload.UserID)
+	log.Info("Processed idpintent.succeeded", "idpProvider", idpProvider, "avatarURL", avatarURL, "userId", userID)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("success"))
+}
+
+const (
+	idpIntentUserLookupAttempts = 8
+	idpIntentUserLookupBaseWait = 250 * time.Millisecond
+)
+
+func miloUserIDFromIdpIntent(req IdpIntentSucceededRequest) string {
+	if id := req.EventPayload.UserID; id != "" {
+		return id
+	}
+	return req.UserID
+}
+
+func (s *Server) getUserWithRetry(ctx context.Context, userID string) (*iammiloapiscomv1alpha1.User, error) {
+	current := &iammiloapiscomv1alpha1.User{}
+	var err error
+
+	for attempt := 0; attempt < idpIntentUserLookupAttempts; attempt++ {
+		err = s.k8sClient.Get(ctx, client.ObjectKey{Name: userID}, current)
+		if err == nil {
+			return current, nil
+		}
+		if !apierrors.IsNotFound(err) || attempt == idpIntentUserLookupAttempts-1 {
+			return nil, err
+		}
+		time.Sleep(idpIntentUserLookupBaseWait * time.Duration(1<<attempt))
+	}
+
+	return nil, err
 }
 
 // parseIDPUserData inspects the raw json of idpUser (base64 decoded) and
@@ -496,6 +538,9 @@ func parseIDPUserData(raw []byte) (iammiloapiscomv1alpha1.AuthProvider, string, 
 	if user, ok := m["User"].(map[string]interface{}); ok {
 		if pic, ok := user["picture"].(string); ok && pic != "" {
 			return iammiloapiscomv1alpha1.AuthProviderGoogle, pic, nil
+		}
+		if avatar, ok := user["avatar_url"].(string); ok && avatar != "" {
+			return iammiloapiscomv1alpha1.AuthProviderGitHub, avatar, nil
 		}
 	}
 

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -48,6 +48,11 @@ type ServerConfig struct {
 	// used to verify the gateway's TLS certificate. When empty the system
 	// cert pool is used (sufficient if the CA is already trusted by the OS).
 	GraphQLGatewayCACertFile string
+	// IdpIntentUserLookupAttempts is how many times to retry fetching the Milo
+	// User when idpintent.succeeded arrives before user.human.added creates it.
+	IdpIntentUserLookupAttempts int
+	// IdpIntentUserLookupBaseWait is the initial backoff between those retries.
+	IdpIntentUserLookupBaseWait time.Duration
 }
 
 type ValidateSignatureFunc func(payload []byte, header string, signingKey string) error
@@ -61,6 +66,8 @@ func NewServerConfig() *ServerConfig {
 		NotificationNamespace:        "milo-system",
 		GraphQLGatewayURL:            "https://graphql-gateway.graphql-gateway.svc.cluster.local:4000/graphql",
 		GraphQLGatewayCACertFile:     "/etc/ssl/certs/datum-ca.crt",
+		IdpIntentUserLookupAttempts:  8,
+		IdpIntentUserLookupBaseWait:  250 * time.Millisecond,
 	}
 }
 
@@ -496,11 +503,6 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 	_, _ = w.Write([]byte("success"))
 }
 
-const (
-	idpIntentUserLookupAttempts = 8
-	idpIntentUserLookupBaseWait = 250 * time.Millisecond
-)
-
 func miloUserIDFromIdpIntent(req IdpIntentSucceededRequest) string {
 	if id := req.EventPayload.UserID; id != "" {
 		return id
@@ -512,15 +514,24 @@ func (s *Server) getUserWithRetry(ctx context.Context, userID string) (*iammiloa
 	current := &iammiloapiscomv1alpha1.User{}
 	var err error
 
-	for attempt := 0; attempt < idpIntentUserLookupAttempts; attempt++ {
+	attempts := s.config.IdpIntentUserLookupAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	baseWait := s.config.IdpIntentUserLookupBaseWait
+	if baseWait < 0 {
+		baseWait = 0
+	}
+
+	for attempt := 0; attempt < attempts; attempt++ {
 		err = s.k8sClient.Get(ctx, client.ObjectKey{Name: userID}, current)
 		if err == nil {
 			return current, nil
 		}
-		if !apierrors.IsNotFound(err) || attempt == idpIntentUserLookupAttempts-1 {
+		if !apierrors.IsNotFound(err) || attempt == attempts-1 {
 			return nil, err
 		}
-		time.Sleep(idpIntentUserLookupBaseWait * time.Duration(1<<attempt))
+		time.Sleep(baseWait * time.Duration(1<<attempt))
 	}
 
 	return nil, err

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -16,13 +16,13 @@ import (
 	"sync"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"go.miloapis.com/auth-provider-zitadel/pkg/zitadel"
 	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ServerConfig holds configuration for the HTTP actions server

--- a/internal/httpactionsserver/server_test.go
+++ b/internal/httpactionsserver/server_test.go
@@ -772,3 +772,77 @@ func TestParseDeviceAndBrowser(t *testing.T) {
 		}
 	}
 }
+
+func TestParseIDPUserData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		provider iamv1alpha1.AuthProvider
+		avatar   string
+		wantErr  bool
+	}{
+		{
+			name:     "google nested picture",
+			raw:      `{"User":{"picture":"https://lh3.googleusercontent.com/a/example"}}`,
+			provider: iamv1alpha1.AuthProviderGoogle,
+			avatar:   "https://lh3.googleusercontent.com/a/example",
+		},
+		{
+			name:     "github nested avatar_url",
+			raw:      `{"User":{"avatar_url":"https://avatars.githubusercontent.com/u/1"}}`,
+			provider: iamv1alpha1.AuthProviderGitHub,
+			avatar:   "https://avatars.githubusercontent.com/u/1",
+		},
+		{
+			name:     "github top-level avatar_url",
+			raw:      `{"avatar_url":"https://avatars.githubusercontent.com/u/2"}`,
+			provider: iamv1alpha1.AuthProviderGitHub,
+			avatar:   "https://avatars.githubusercontent.com/u/2",
+		},
+		{
+			name:    "unknown provider",
+			raw:     `{"email":"nobody@example.com"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider, avatar, err := parseIDPUserData([]byte(tt.raw))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if provider != tt.provider {
+				t.Fatalf("provider = %q, want %q", provider, tt.provider)
+			}
+			if avatar != tt.avatar {
+				t.Fatalf("avatar = %q, want %q", avatar, tt.avatar)
+			}
+		})
+	}
+}
+
+func TestMiloUserIDFromIdpIntent(t *testing.T) {
+	t.Parallel()
+
+	req := IdpIntentSucceededRequest{}
+	req.EventPayload.UserID = "payload-id"
+	if got := miloUserIDFromIdpIntent(req); got != "payload-id" {
+		t.Fatalf("got %q, want payload-id", got)
+	}
+
+	req = IdpIntentSucceededRequest{UserID: "top-level-id"}
+	if got := miloUserIDFromIdpIntent(req); got != "top-level-id" {
+		t.Fatalf("got %q, want top-level-id", got)
+	}
+}

--- a/internal/httpactionsserver/server_test.go
+++ b/internal/httpactionsserver/server_test.go
@@ -809,7 +809,6 @@ func TestParseIDPUserData(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			provider, avatar, err := parseIDPUserData([]byte(tt.raw))

--- a/test/serviceaccountkey-generation/chainsaw-test.yaml
+++ b/test/serviceaccountkey-generation/chainsaw-test.yaml
@@ -29,7 +29,7 @@ spec:
           # Compute username
           SA_UID=$(kubectl get serviceaccounts.iam.miloapis.com sa-generation -o jsonpath='{.metadata.uid}')
           SA_USERNAME="sa-generation@single.identity.miloapis.com"
-          echo "$SA_USERNAME" > /tmp/sa_username.txt
+          echo "$SA_USERNAME" > /tmp/sa-generation-username.txt
 
           # Create Key without publicKey payload
           POST_RESPONSE=$(jq -n \
@@ -43,16 +43,16 @@ spec:
               -d @-)
 
           KEY_ID=$(printf '%s\n' "$POST_RESPONSE" | jq -r '.status.authProviderKeyID')
-          if [ -z "$KEY_ID" ] || [ "$KEY_ID" == "null" ]; then
+          if [ -z "$KEY_ID" ] || [ "$KEY_ID" = "null" ]; then
             echo "ERROR: Failed to extract authProviderKeyID from response:"
             printf '%s\n' "$POST_RESPONSE"
             exit 1
           fi
           echo "KEY_ID: $KEY_ID"
-          echo "$KEY_ID" > /tmp/gen_key_id.txt
+          echo "$KEY_ID" > /tmp/sa-generation-key-id.txt
 
           PRIVATE_KEY_JSON=$(printf '%s\n' "$POST_RESPONSE" | jq -r '.status.privateKey')
-          if [ -z "$PRIVATE_KEY_JSON" ] || [ "$PRIVATE_KEY_JSON" == "null" ]; then
+          if [ -z "$PRIVATE_KEY_JSON" ] || [ "$PRIVATE_KEY_JSON" = "null" ]; then
             echo "ERROR: Failed to extract generated privateKey from response payload:"
             printf '%s\n' "$POST_RESPONSE"
             exit 1
@@ -61,20 +61,20 @@ spec:
           # status.privateKey is the Datum credentials file format used by
           # datumctl. Support the same base64-or-raw fallback the old test had
           # in case transports re-encode the field.
-          printf '%s\n' "$PRIVATE_KEY_JSON" | base64 -d > /tmp/datum-credentials.json 2>/dev/null || printf '%s\n' "$PRIVATE_KEY_JSON" > /tmp/datum-credentials.json
+          printf '%s\n' "$PRIVATE_KEY_JSON" | base64 -d > /tmp/sa-generation-datum-credentials.json 2>/dev/null || printf '%s\n' "$PRIVATE_KEY_JSON" > /tmp/sa-generation-datum-credentials.json
 
           # Verify the Datum credentials file has all required fields.
-          CREDS_TYPE=$(jq -r '.type' /tmp/datum-credentials.json)
+          CREDS_TYPE=$(jq -r '.type' /tmp/sa-generation-datum-credentials.json)
           if [ "$CREDS_TYPE" != "datum_service_account" ]; then
             echo "ERROR: Expected credentials type 'datum_service_account', got '$CREDS_TYPE'"
-            cat /tmp/datum-credentials.json
+            cat /tmp/sa-generation-datum-credentials.json
             exit 1
           fi
           for field in client_id private_key_id private_key client_email; do
-            VALUE=$(jq -r ".${field}" /tmp/datum-credentials.json)
-            if [ -z "$VALUE" ] || [ "$VALUE" == "null" ]; then
+            VALUE=$(jq -r ".${field}" /tmp/sa-generation-datum-credentials.json)
+            if [ -z "$VALUE" ] || [ "$VALUE" = "null" ]; then
               echo "ERROR: Datum credentials missing required field: $field"
-              cat /tmp/datum-credentials.json
+              cat /tmp/sa-generation-datum-credentials.json
               exit 1
             fi
           done
@@ -83,7 +83,7 @@ spec:
           # zitadel-tools key2jwt (which expects Zitadel's shape) can sign a
           # JWT assertion from the generated private key in the next step.
           jq '{type: "serviceaccount", keyId: .private_key_id, key: .private_key, userId: .client_id}' \
-            /tmp/datum-credentials.json > /tmp/zitadel-key-gen.json
+            /tmp/sa-generation-datum-credentials.json > /tmp/sa-generation-zitadel-key.json
 
           echo "Successfully created ServiceAccountKey and captured the Datum credentials payload!"
 
@@ -96,7 +96,7 @@ spec:
           # This ensures the generated key config JSON from Zitadel is completely valid
           ../../bin/zitadel-tools key2jwt \
             --audience="https://zitadel.zitadel-system.svc.cluster.local" \
-            --key="/tmp/zitadel-key-gen.json" > /tmp/jwt-gen.token
+            --key="/tmp/sa-generation-zitadel-key.json" > /tmp/sa-generation-jwt.token
 
           # Get access token from ZITADEL
           RESPONSE=$(curl -k -s -X POST "$ZITADEL_DOMAIN/oauth/v2/token" \
@@ -104,10 +104,10 @@ spec:
             -H "Host: zitadel.zitadel-system.svc.cluster.local" \
             --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer" \
             --data-urlencode "scope=urn:zitadel:iam:org:project:id:zitadel:aud" \
-            --data-urlencode "assertion=$(cat /tmp/jwt-gen.token)")
+            --data-urlencode "assertion=$(cat /tmp/sa-generation-jwt.token)")
 
           ACCESS_TOKEN=$(printf '%s\n' "$RESPONSE" | jq -r '.access_token')
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" == "null" ]; then
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
             echo "ERROR: Failed to obtain access token with the generated key. Response: $RESPONSE"
             exit 1
           fi

--- a/test/serviceaccountkey-lifecycle/chainsaw-test.yaml
+++ b/test/serviceaccountkey-lifecycle/chainsaw-test.yaml
@@ -55,7 +55,7 @@ spec:
           # Extract authProviderKeyID from the response status
           printf '%s\n' "$POST_RESPONSE"
           KEY_ID=$(printf '%s\n' "$POST_RESPONSE" | jq -r '.status.authProviderKeyID')
-          if [ -z "$KEY_ID" ] || [ "$KEY_ID" == "null" ]; then
+          if [ -z "$KEY_ID" ] || [ "$KEY_ID" = "null" ]; then
             echo "ERROR: Failed to extract authProviderKeyID. Response: $POST_RESPONSE"
             exit 1
           fi
@@ -89,7 +89,7 @@ spec:
             --data-urlencode "assertion=$(cat /tmp/jwt-deact.token)")
 
           ACCESS_TOKEN=$(printf '%s\n' "$RESPONSE" | jq -r '.access_token')
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" == "null" ]; then
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
             echo "ERROR: Failed to obtain access token before deactivation. Response: $RESPONSE"
             exit 1
           fi
@@ -135,7 +135,7 @@ spec:
             --data-urlencode "assertion=$(cat /tmp/jwt-deact.token)")
 
           ERROR=$(printf '%s\n' "$RESPONSE" | jq -r '.error')
-          if [ "$ERROR" == "null" ] || [ -z "$ERROR" ]; then
+          if [ "$ERROR" = "null" ] || [ -z "$ERROR" ]; then
             echo "ERROR: Access token exchange did not fail as expected when deactivated! Response: $RESPONSE"
             exit 1
           fi
@@ -181,7 +181,7 @@ spec:
             --data-urlencode "assertion=$(cat /tmp/jwt-deact.token)")
 
           ACCESS_TOKEN=$(printf '%s\n' "$RESPONSE" | jq -r '.access_token')
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" == "null" ]; then
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
             echo "ERROR: Failed to obtain access token after reactivation. Response: $RESPONSE"
             exit 1
           fi

--- a/test/serviceaccountkey/chainsaw-test.yaml
+++ b/test/serviceaccountkey/chainsaw-test.yaml
@@ -32,12 +32,12 @@ spec:
           # The Zitadel username is the computed email: {name}@single.identity.miloapis.com
           SA_UID=$(kubectl get serviceaccounts.iam.miloapis.com sa-keys -o jsonpath='{.metadata.uid}')
           SA_USERNAME="sa-keys@single.identity.miloapis.com"
-          echo "$SA_USERNAME" > /tmp/sa_username.txt
+          echo "$SA_USERNAME" > /tmp/sa-keys-username.txt
 
           # Create Key 1
-          openssl genrsa -out /tmp/key1-priv.pem 2048 2>/dev/null
-          openssl rsa -in /tmp/key1-priv.pem -pubout -out /tmp/key1-pub.pem 2>/dev/null
-          KEY1_PUB_KEY=$(cat /tmp/key1-pub.pem)
+          openssl genrsa -out /tmp/sa-keys-key1-priv.pem 2048 2>/dev/null
+          openssl rsa -in /tmp/sa-keys-key1-priv.pem -pubout -out /tmp/sa-keys-key1-pub.pem 2>/dev/null
+          KEY1_PUB_KEY=$(cat /tmp/sa-keys-key1-pub.pem)
 
           POST_RESPONSE_1=$(jq -n \
             --arg serviceAccountUserName "$SA_USERNAME" \
@@ -51,18 +51,18 @@ spec:
               -d @-)
 
           KEY1_ID=$(printf '%s\n' "$POST_RESPONSE_1" | jq -r '.status.authProviderKeyID')
-          if [ -z "$KEY1_ID" ] || [ "$KEY1_ID" == "null" ]; then
+          if [ -z "$KEY1_ID" ] || [ "$KEY1_ID" = "null" ]; then
             echo "ERROR: Failed to extract KEY1_ID from response:"
             printf '%s\n' "$POST_RESPONSE_1"
             exit 1
           fi
           echo "KEY1_ID: $KEY1_ID"
-          echo "$KEY1_ID" > /tmp/key1_id.txt
+          echo "$KEY1_ID" > /tmp/sa-keys-key1-id.txt
 
           # Create Key 2
-          openssl genrsa -out /tmp/key2-priv.pem 2048 2>/dev/null
-          openssl rsa -in /tmp/key2-priv.pem -pubout -out /tmp/key2-pub.pem 2>/dev/null
-          KEY2_PUB_KEY=$(cat /tmp/key2-pub.pem)
+          openssl genrsa -out /tmp/sa-keys-key2-priv.pem 2048 2>/dev/null
+          openssl rsa -in /tmp/sa-keys-key2-priv.pem -pubout -out /tmp/sa-keys-key2-pub.pem 2>/dev/null
+          KEY2_PUB_KEY=$(cat /tmp/sa-keys-key2-pub.pem)
 
           POST_RESPONSE_2=$(jq -n \
             --arg serviceAccountUserName "$SA_USERNAME" \
@@ -76,20 +76,20 @@ spec:
               -d @-)
 
           KEY2_ID=$(printf '%s\n' "$POST_RESPONSE_2" | jq -r '.status.authProviderKeyID')
-          if [ -z "$KEY2_ID" ] || [ "$KEY2_ID" == "null" ]; then
+          if [ -z "$KEY2_ID" ] || [ "$KEY2_ID" = "null" ]; then
             echo "ERROR: Failed to extract KEY2_ID from response:"
             printf '%s\n' "$POST_RESPONSE_2"
             exit 1
           fi
           echo "KEY2_ID: $KEY2_ID"
-          echo "$KEY2_ID" > /tmp/key2_id.txt
+          echo "$KEY2_ID" > /tmp/sa-keys-key2-id.txt
 
   - name: list-and-verify-two-keys
     try:
     - script:
         content: |
           set -e
-          SA_USERNAME=$(cat /tmp/sa_username.txt)
+          SA_USERNAME=$(cat /tmp/sa-keys-username.txt)
 
           LIST_RESPONSE=$(curl -s -G "http://localhost:8001/apis/identity.miloapis.com/v1alpha1/serviceaccountkeys" \
             --data-urlencode "fieldSelector=spec.serviceAccountUserName=${SA_USERNAME}" \
@@ -110,7 +110,7 @@ spec:
     - script:
         content: |
           set -e
-          KEY1_ID=$(cat /tmp/key1_id.txt)
+          KEY1_ID=$(cat /tmp/sa-keys-key1-id.txt)
 
           # Delete Key 1. Target resource name is the keyID
           DELETE_RESPONSE=$(curl -s -X DELETE "http://localhost:8001/apis/identity.miloapis.com/v1alpha1/serviceaccountkeys/${KEY1_ID}" \
@@ -126,8 +126,8 @@ spec:
     - script:
         content: |
           set -e
-          SA_USERNAME=$(cat /tmp/sa_username.txt)
-          KEY2_ID=$(cat /tmp/key2_id.txt)
+          SA_USERNAME=$(cat /tmp/sa-keys-username.txt)
+          KEY2_ID=$(cat /tmp/sa-keys-key2-id.txt)
 
           LIST_RESPONSE=$(curl -s -G "http://localhost:8001/apis/identity.miloapis.com/v1alpha1/serviceaccountkeys" \
             --data-urlencode "fieldSelector=spec.serviceAccountUserName=${SA_USERNAME}" \


### PR DESCRIPTION
## Summary

Google and GitHub signups were missing profile pictures until the user logged out and back in. On first OAuth signup, `idpintent.succeeded` can fire before `user.human.added` creates the Milo User, so the avatar patch returned 404 and was dropped.

This adds exponential backoff while waiting for the User resource to exist, resolves `userId` from either field Zitadel sends, and reads GitHub `avatar_url` when it is nested under `User`.

## Test plan

- [x] `go test ./internal/httpactionsserver/...` passes locally
- [ ] Sign up with a fresh Google account in staging and confirm avatar appears without re-login
- [ ] Sign up with a fresh GitHub account in staging and confirm avatar appears without re-login
- [ ] Confirm existing logins still patch `lastLoginProvider` and `avatarUrl`