### PR TITLE
fix: Sync IdP avatar on first OAuth signup

### DIFF
--- a/internal/httpactionsserver/avatar_sync.go
+++ b/internal/httpactionsserver/avatar_sync.go
@@ -1,0 +1,131 @@
+package httpactionsserver
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+)
+
+const pendingAvatarTTL = 15 * time.Minute
+
+type pendingAvatar struct {
+	avatarURL string
+	provider  iammiloapiscomv1alpha1.AuthProvider
+	expiresAt time.Time
+}
+
+var pendingAvatars sync.Map
+
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func decodeIDPUserPayload(encoded string) ([]byte, error) {
+	trimmed := strings.TrimSpace(encoded)
+	if trimmed == "" {
+		return nil, errors.New("empty idpUser")
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		if json.Valid([]byte(trimmed)) {
+			return []byte(trimmed), nil
+		}
+	}
+	if raw, err := base64.StdEncoding.DecodeString(trimmed); err == nil {
+		if json.Valid(raw) {
+			return raw, nil
+		}
+	}
+	return nil, errors.New("idpUser is neither valid JSON nor base64-encoded JSON")
+}
+
+func storePendingAvatar(email, avatarURL string, provider iammiloapiscomv1alpha1.AuthProvider) {
+	email = normalizeEmail(email)
+	if email == "" || avatarURL == "" {
+		return
+	}
+	pendingAvatars.Store(email, pendingAvatar{
+		avatarURL: avatarURL,
+		provider:  provider,
+		expiresAt: time.Now().Add(pendingAvatarTTL),
+	})
+}
+
+func consumePendingAvatar(email string) (pendingAvatar, bool) {
+	email = normalizeEmail(email)
+	if email == "" {
+		return pendingAvatar{}, false
+	}
+	value, ok := pendingAvatars.LoadAndDelete(email)
+	if !ok {
+		return pendingAvatar{}, false
+	}
+	pending, ok := value.(pendingAvatar)
+	if !ok || time.Now().After(pending.expiresAt) {
+		return pendingAvatar{}, false
+	}
+	return pending, true
+}
+
+func extractEmailFromIDPUserData(raw []byte) string {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	if user, ok := m["User"].(map[string]any); ok {
+		if email, ok := user["email"].(string); ok {
+			return normalizeEmail(email)
+		}
+	}
+	if email, ok := m["email"].(string); ok {
+		return normalizeEmail(email)
+	}
+	return ""
+}
+
+func (s *Server) patchUserAvatar(
+	ctx context.Context,
+	log logr.Logger,
+	userID string,
+	avatarURL string,
+	provider iammiloapiscomv1alpha1.AuthProvider,
+	fieldManager string,
+) error {
+	current := &iammiloapiscomv1alpha1.User{}
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{Name: userID}, current); err != nil {
+		return err
+	}
+	original := current.DeepCopy()
+	current.Status.AvatarURL = avatarURL
+	current.Status.LastLoginProvider = provider
+	if err := s.k8sClient.Status().Patch(ctx, current, client.MergeFrom(original), client.FieldOwner(fieldManager)); err != nil {
+		return err
+	}
+	log.Info("Patched user avatar", "userId", userID, "avatarURL", avatarURL, "idpProvider", provider)
+	return nil
+}
+
+func (s *Server) applyPendingAvatarByEmail(
+	ctx context.Context,
+	log logr.Logger,
+	userID, email, fieldManager string,
+) bool {
+	pending, ok := consumePendingAvatar(email)
+	if !ok {
+		return false
+	}
+	if err := s.patchUserAvatar(ctx, log, userID, pending.avatarURL, pending.provider, fieldManager); err != nil {
+		log.Error(err, "Failed to apply pending avatar", "userId", userID, "email", email)
+		storePendingAvatar(email, pending.avatarURL, pending.provider)
+		return false
+	}
+	return true
+}

--- a/internal/httpactionsserver/avatar_sync_test.go
+++ b/internal/httpactionsserver/avatar_sync_test.go
@@ -1,0 +1,112 @@
+package httpactionsserver
+
+import (
+	"encoding/base64"
+	"sync"
+	"testing"
+	"time"
+
+	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+)
+
+func TestExtractEmailFromIDPUserData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		raw   string
+		email string
+	}{
+		{
+			name:  "google nested email",
+			raw:   `{"User":{"email":"Ada@Example.com","picture":"https://example.com/a.png"}}`,
+			email: "ada@example.com",
+		},
+		{
+			name:  "github top-level email",
+			raw:   `{"email":"dev@users.noreply.github.com","avatar_url":"https://avatars.githubusercontent.com/u/1"}`,
+			email: "dev@users.noreply.github.com",
+		},
+		{
+			name:  "missing email",
+			raw:   `{"User":{"picture":"https://example.com/a.png"}}`,
+			email: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractEmailFromIDPUserData([]byte(tt.raw)); got != tt.email {
+				t.Fatalf("email = %q, want %q", got, tt.email)
+			}
+		})
+	}
+}
+
+func TestDecodeIDPUserPayload(t *testing.T) {
+	t.Parallel()
+
+	rawJSON := `{"User":{"email":"ada@example.com","picture":"https://example.com/a.png"}}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(rawJSON))
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "base64 wrapped", input: encoded, want: rawJSON},
+		{name: "raw json", input: rawJSON, want: rawJSON},
+		{name: "invalid", input: "not-json", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := decodeIDPUserPayload(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decodeIDPUserPayload() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestPendingAvatarCache(t *testing.T) {
+	t.Parallel()
+
+	pendingAvatars = sync.Map{}
+
+	storePendingAvatar("user@example.com", "https://example.com/a.png", iammiloapiscomv1alpha1.AuthProviderGoogle)
+	pending, ok := consumePendingAvatar("user@example.com")
+	if !ok {
+		t.Fatal("expected pending avatar")
+	}
+	if pending.avatarURL != "https://example.com/a.png" {
+		t.Fatalf("avatarURL = %q", pending.avatarURL)
+	}
+	if pending.provider != iammiloapiscomv1alpha1.AuthProviderGoogle {
+		t.Fatalf("provider = %q", pending.provider)
+	}
+	if _, ok := consumePendingAvatar("user@example.com"); ok {
+		t.Fatal("expected pending avatar to be consumed")
+	}
+
+	pendingAvatars.Store("expired@example.com", pendingAvatar{
+		avatarURL: "https://example.com/expired.png",
+		provider:  iammiloapiscomv1alpha1.AuthProviderGitHub,
+		expiresAt: time.Now().Add(-time.Minute),
+	})
+	if _, ok := consumePendingAvatar("expired@example.com"); ok {
+		t.Fatal("expected expired pending avatar to be ignored")
+	}
+}

--- a/internal/httpactionsserver/server.go
+++ b/internal/httpactionsserver/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -278,6 +277,10 @@ func (s *Server) createUserAccountHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if s.applyPendingAvatarByEmail(r.Context(), log, req.AggregateID, req.EventPayload.Email, "create-user-account") {
+		log.Info("Applied pending avatar from idp intent", "userName", req.AggregateID, "email", req.EventPayload.Email)
+	}
+
 	log.Info("Successfully created user resource",
 		"userName", req.UserID,
 		"email", req.EventPayload.Email,
@@ -445,8 +448,8 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Decode idpUser JSON
-	raw, err := base64.StdEncoding.DecodeString(req.EventPayload.IDPUser)
+	// Decode idpUser JSON (base64-wrapped bytes or raw JSON, depending on Zitadel version).
+	raw, err := decodeIDPUserPayload(req.EventPayload.IDPUser)
 	if err != nil {
 		log.Error(err, "Failed to decode idpUser")
 		http.Error(w, "invalid idpUser", http.StatusBadRequest)
@@ -463,6 +466,14 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 
 	userID := miloUserIDFromIdpIntent(req)
 	if userID == "" {
+		email := extractEmailFromIDPUserData(raw)
+		if email != "" {
+			storePendingAvatar(email, avatarURL, idpProvider)
+			log.Info("Stored pending avatar for new signup", "email", email, "idpProvider", idpProvider, "avatarURL", avatarURL)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("pending"))
+			return
+		}
 		log.Error(nil, "User ID not found in idpintent.succeeded payload")
 		http.Error(w, "userID not found in payload", http.StatusBadRequest)
 		return
@@ -473,6 +484,14 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		log.Error(err, "Failed to get User resource", "userId", userID)
 		if apierrors.IsNotFound(err) {
+			email := extractEmailFromIDPUserData(raw)
+			if email != "" {
+				storePendingAvatar(email, avatarURL, idpProvider)
+				log.Info("Stored pending avatar after user lookup miss", "email", email, "userId", userID)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("pending"))
+				return
+			}
 			http.Error(w, "user not found", http.StatusNotFound)
 			return
 		}
@@ -497,10 +516,7 @@ func (s *Server) idpIntentSucceededHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func miloUserIDFromIdpIntent(req IdpIntentSucceededRequest) string {
-	if id := req.EventPayload.UserID; id != "" {
-		return id
-	}
-	return req.UserID
+	return req.EventPayload.UserID
 }
 
 func (s *Server) getUserWithRetry(ctx context.Context, userID string) (*iammiloapiscomv1alpha1.User, error) {

--- a/internal/httpactionsserver/server_test.go
+++ b/internal/httpactionsserver/server_test.go
@@ -935,7 +935,7 @@ func TestMiloUserIDFromIdpIntent(t *testing.T) {
 	}
 
 	req = IdpIntentSucceededRequest{UserID: "top-level-id"}
-	if got := miloUserIDFromIdpIntent(req); got != "top-level-id" {
-		t.Fatalf("got %q, want top-level-id", got)
+	if got := miloUserIDFromIdpIntent(req); got != "" {
+		t.Fatalf("got %q, want empty (top-level userID is the event creator)", got)
 	}
 }

--- a/internal/httpactionsserver/session_added.go
+++ b/internal/httpactionsserver/session_added.go
@@ -98,6 +98,12 @@ func (s *Server) sessionAddedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if zitadelUser, err := zClient.GetUserByID(r.Context(), userID); err == nil && zitadelUser != nil && zitadelUser.Email != "" {
+		if s.applyPendingAvatarByEmail(r.Context(), log, userID, zitadelUser.Email, "session-added") {
+			log.Info("Applied pending avatar during session added", "userId", userID, "email", zitadelUser.Email)
+		}
+	}
+
 	var currentIP string
 	var currentUserAgent string
 	var currentFingerprint string


### PR DESCRIPTION
## Summary

Google and GitHub profile pictures were missing on first login because Zitadel fires `idpintent.succeeded` before a user account exists. The webhook arrives with an empty `userId`, so v0.8.9 rejected the payload and threw away the avatar and provider data. A second login worked because the user ID was present by then.

This caches avatar data by email when `userId` is missing, applies it during `create-user-account` (before the OAuth redirect back to cloud-portal), and uses `oidc_session.added` as a backup. It also stops reading the top-level `userId` field, which is the event creator, not the human user.

## Test plan

- [x] `go test ./internal/httpactionsserver/...` passes
- [ ] Fresh Google signup in staging: avatar and provider badge show on first login
- [ ] Fresh GitHub signup in staging: same check
- [ ] Returning user login still patches avatar without pending cache
- [ ] actions-server logs show `Stored pending avatar` then `Applied pending avatar from idp intent`

## Notes for reviewers

- Pending cache is in-process with a 15 minute TTL. Fine for the signup window; a pod restart between idp intent and user creation would drop it, which is why `session-added` is the backup.
- Pairs with datum-cloud/infra#3285 for `user.human.selfregistered` wiring.