### PR TITLE
feat: add ListPasskeys and exempt passkey-verified sessions from suspicious-login email

### DIFF
--- a/internal/httpactionsserver/server_test.go
+++ b/internal/httpactionsserver/server_test.go
@@ -450,6 +450,43 @@ func TestSessionAddedHandler(t *testing.T) {
 			},
 			wantSuspicious: false,
 		},
+		{
+			name: "Passkey-authenticated session is exempt even with a new IP",
+			reqPayload: sessionAddedRequest{
+				AggregateID: "sess-curr",
+				EventType:   "oidc_session.added",
+				UserID:      "user-1",
+				EventPayload: struct {
+					UserID    string     `json:"userID"`
+					SessionID string     `json:"sessionID"`
+					UserAgent *userAgent `json:"userAgent"`
+				}{
+					UserID: "user-1",
+					UserAgent: &userAgent{
+						IP:          "9.9.9.9",
+						Description: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					},
+				},
+			},
+			mockSessions: []zitadel.Session{
+				{
+					ID:              "sess-curr",
+					UserID:          "user-1",
+					IP:              "9.9.9.9",
+					UserAgent:       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36",
+					CreatedAt:       time.Now(),
+					PasskeyVerified: true,
+				},
+				{
+					ID:        "sess-prev",
+					UserID:    "user-1",
+					IP:        "1.1.1.1",
+					UserAgent: "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/120.0",
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				},
+			},
+			wantSuspicious: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/httpactionsserver/server_test.go
+++ b/internal/httpactionsserver/server_test.go
@@ -43,6 +43,9 @@ func (m *mockZitadelAPI) DeleteSession(ctx context.Context, userID, sessionID st
 func (m *mockZitadelAPI) ListIDPLinks(ctx context.Context, userID string) ([]zitadel.IDPLink, error) {
 	return nil, nil
 }
+func (m *mockZitadelAPI) ListPasskeys(ctx context.Context, userID string) ([]zitadel.Passkey, error) {
+	return nil, nil
+}
 func (m *mockZitadelAPI) CreateOrganization(ctx context.Context, name string) (string, error) {
 	return "", nil
 }

--- a/internal/httpactionsserver/session_added.go
+++ b/internal/httpactionsserver/session_added.go
@@ -121,6 +121,13 @@ func (s *Server) sessionAddedHandler(w http.ResponseWriter, r *http.Request) {
 		sessionID = req.AggregateID
 	}
 
+	if current := findSessionByID(sessions, sessionID); current != nil && current.PasskeyVerified {
+		log.Info("Session authenticated via passkey; exempting from suspicious-login check", "userId", userID, "sessionId", sessionID)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+		return
+	}
+
 	previousSessions := getPreviousSessions(sessions, sessionID)
 	if len(previousSessions) > 0 {
 		if isSuspiciousLogin(log, previousSessions, currentIP, currentUserAgent, currentFingerprint) {
@@ -132,6 +139,20 @@ func (s *Server) sessionAddedHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("success"))
+}
+
+// findSessionByID returns a pointer to the session with the given ID within
+// sessions, or nil if absent. Used to recover the current session's factor
+// detail (e.g. PasskeyVerified) from the full list already fetched via
+// ListSessions — the session.added webhook payload itself carries no
+// factor information.
+func findSessionByID(sessions []zitadel.Session, id string) *zitadel.Session {
+	for i := range sessions {
+		if sessions[i].ID == id {
+			return &sessions[i]
+		}
+	}
+	return nil
 }
 
 // getPreviousSessions filters the list of sessions to return all sessions other than the current one.

--- a/pkg/zitadel/api.go
+++ b/pkg/zitadel/api.go
@@ -45,6 +45,17 @@ type IDPLink struct {
 	IDPUserName string
 }
 
+// Passkey represents a Zitadel WebAuthn passkey credential for a user.
+type Passkey struct {
+	ID   string
+	Name string
+	// State is the raw Zitadel AuthFactorState string (e.g.
+	// "AUTH_FACTOR_STATE_READY"). Callers map it to a domain-level
+	// Active/Inactive status; this package stays a thin, faithful mirror
+	// of the Zitadel wire shape (see User.State for the same convention).
+	State string
+}
+
 // User represents a Zitadel user with minimal fields.
 type User struct {
 	ID       string
@@ -76,6 +87,9 @@ type API interface {
 	GetSession(ctx context.Context, sessionID string) (*Session, error)
 	DeleteSession(ctx context.Context, userID, sessionID string) error
 	ListIDPLinks(ctx context.Context, userID string) ([]IDPLink, error)
+
+	// passkey management
+	ListPasskeys(ctx context.Context, userID string) ([]Passkey, error)
 
 	// organization management
 	CreateOrganization(ctx context.Context, name string) (orgID string, err error)

--- a/pkg/zitadel/api.go
+++ b/pkg/zitadel/api.go
@@ -35,6 +35,12 @@ type Session struct {
 	// the milo Session as annotations so they can be read by downstream
 	// consumers like the fraud service.
 	Metadata map[string]string
+	// PasskeyVerified is true when this session's most recent authentication
+	// included a user-verified WebAuthN factor (Factors.WebAuthN.UserVerified) —
+	// the closest available signal that the login was a passkey/passwordless
+	// ceremony rather than password+OTP. Used to exempt passkey logins from
+	// the suspicious-login notification (see internal/httpactionsserver).
+	PasskeyVerified bool
 }
 
 // IDPLink represents an identity provider link for a user.

--- a/pkg/zitadel/sdk_client.go
+++ b/pkg/zitadel/sdk_client.go
@@ -154,14 +154,15 @@ func (c *SDKClient) mapZitadelSession(s *sessionv2.Session) Session {
 		}
 	}
 	return Session{
-		ID:            s.GetId(),
-		UserID:        s.GetFactors().GetUser().GetId(),
-		IP:            ip,
-		FingerprintID: fingerprint,
-		CreatedAt:     toTime(s.GetCreationDate()),
-		LastUpdated:   lastUpdated,
-		UserAgent:     extractUserAgentString(zeUA),
-		Metadata:      metadata,
+		ID:              s.GetId(),
+		UserID:          s.GetFactors().GetUser().GetId(),
+		IP:              ip,
+		FingerprintID:   fingerprint,
+		CreatedAt:       toTime(s.GetCreationDate()),
+		LastUpdated:     lastUpdated,
+		UserAgent:       extractUserAgentString(zeUA),
+		Metadata:        metadata,
+		PasskeyVerified: s.GetFactors().GetWebAuthN().GetUserVerified(),
 	}
 }
 

--- a/pkg/zitadel/sdk_client.go
+++ b/pkg/zitadel/sdk_client.go
@@ -315,6 +315,30 @@ func localIdentityUsername(user *userv2.User) string {
 	return strings.TrimSpace(user.GetUsername())
 }
 
+// ListPasskeys retrieves all WebAuthn passkey credentials for a user using
+// the v2 UserService. Unlike ListHumanUsers this RPC takes no pagination
+// query — Zitadel returns the user's full passkey set in one call.
+func (c *SDKClient) ListPasskeys(ctx context.Context, userID string) ([]Passkey, error) {
+	klog.V(2).Infof("ListPasskeys: listing passkeys for userID=%q", userID)
+
+	resp, err := c.user.ListPasskeys(ctx, &userv2.ListPasskeysRequest{UserId: userID})
+	if err != nil {
+		klog.Errorf("ListPasskeys: API call failed for userID=%q: %v", userID, err)
+		return nil, fmt.Errorf("list passkeys: %w", err)
+	}
+
+	out := make([]Passkey, 0, len(resp.GetResult()))
+	for _, p := range resp.GetResult() {
+		out = append(out, Passkey{
+			ID:    p.GetId(),
+			Name:  p.GetName(),
+			State: p.GetState().String(),
+		})
+	}
+	klog.V(2).Infof("ListPasskeys: found %d passkey(s) for userID=%q", len(out), userID)
+	return out, nil
+}
+
 // CreateOrganization creates a new organization in Zitadel with a custom name.
 // Returns the organization ID.
 func (c *SDKClient) CreateOrganization(ctx context.Context, name string) (string, error) {

--- a/pkg/zitadel/sdk_client_test.go
+++ b/pkg/zitadel/sdk_client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	sessionv2 "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/session/v2"
 	userv2 "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
 	"google.golang.org/grpc"
 )
@@ -191,4 +192,26 @@ func TestListPasskeys(t *testing.T) {
 			t.Fatalf("expected wrapped boom error, got %v", err)
 		}
 	})
+}
+
+func TestMapZitadelSessionPasskeyVerified(t *testing.T) {
+	c := &SDKClient{}
+	tests := []struct {
+		name    string
+		factors *sessionv2.Factors
+		want    bool
+	}{
+		{"nil factors", nil, false},
+		{"no webAuthN factor", &sessionv2.Factors{}, false},
+		{"webAuthN present but not user-verified", &sessionv2.Factors{WebAuthN: &sessionv2.WebAuthNFactor{UserVerified: false}}, false},
+		{"webAuthN user-verified (passkey)", &sessionv2.Factors{WebAuthN: &sessionv2.WebAuthNFactor{UserVerified: true}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := c.mapZitadelSession(&sessionv2.Session{Factors: tt.factors})
+			if s.PasskeyVerified != tt.want {
+				t.Errorf("PasskeyVerified = %v, want %v", s.PasskeyVerified, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/zitadel/sdk_client_test.go
+++ b/pkg/zitadel/sdk_client_test.go
@@ -9,15 +9,20 @@ import (
 	"google.golang.org/grpc"
 )
 
-// fakeUserService stubs the gRPC UserServiceClient. Only ListUsers is
-// implemented; any other call panics via the embedded nil interface.
+// fakeUserService stubs the gRPC UserServiceClient. Only the methods under
+// test are implemented; any other call panics via the embedded nil interface.
 type fakeUserService struct {
 	userv2.UserServiceClient
-	listUsers func(ctx context.Context, in *userv2.ListUsersRequest, opts ...grpc.CallOption) (*userv2.ListUsersResponse, error)
+	listUsers    func(ctx context.Context, in *userv2.ListUsersRequest, opts ...grpc.CallOption) (*userv2.ListUsersResponse, error)
+	listPasskeys func(ctx context.Context, in *userv2.ListPasskeysRequest, opts ...grpc.CallOption) (*userv2.ListPasskeysResponse, error)
 }
 
 func (f *fakeUserService) ListUsers(ctx context.Context, in *userv2.ListUsersRequest, opts ...grpc.CallOption) (*userv2.ListUsersResponse, error) {
 	return f.listUsers(ctx, in, opts...)
+}
+
+func (f *fakeUserService) ListPasskeys(ctx context.Context, in *userv2.ListPasskeysRequest, opts ...grpc.CallOption) (*userv2.ListPasskeysResponse, error) {
+	return f.listPasskeys(ctx, in, opts...)
 }
 
 func humanUser(id, username, email, given, family string, state userv2.UserState) *userv2.User {
@@ -120,6 +125,68 @@ func TestListHumanUsers(t *testing.T) {
 		_, _, err := c.ListHumanUsers(context.Background(), 0, 10)
 
 		// Assert
+		if !errors.Is(err, boom) {
+			t.Fatalf("expected wrapped boom error, got %v", err)
+		}
+	})
+}
+
+func TestListPasskeys(t *testing.T) {
+	t.Run("maps passkeys with raw AuthFactorState strings", func(t *testing.T) {
+		// Arrange
+		var gotReq *userv2.ListPasskeysRequest
+		c := &SDKClient{user: &fakeUserService{
+			listPasskeys: func(_ context.Context, in *userv2.ListPasskeysRequest, _ ...grpc.CallOption) (*userv2.ListPasskeysResponse, error) {
+				gotReq = in
+				return &userv2.ListPasskeysResponse{Result: []*userv2.Passkey{
+					{Id: "pk-1", Name: "MacBook Touch ID", State: userv2.AuthFactorState_AUTH_FACTOR_STATE_READY},
+					{Id: "pk-2", Name: "Old YubiKey", State: userv2.AuthFactorState_AUTH_FACTOR_STATE_NOT_READY},
+				}}, nil
+			},
+		}}
+
+		// Act
+		passkeys, err := c.ListPasskeys(context.Background(), "user-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []Passkey{
+			{ID: "pk-1", Name: "MacBook Touch ID", State: "AUTH_FACTOR_STATE_READY"},
+			{ID: "pk-2", Name: "Old YubiKey", State: "AUTH_FACTOR_STATE_NOT_READY"},
+		}
+		if len(passkeys) != len(want) || passkeys[0] != want[0] || passkeys[1] != want[1] {
+			t.Errorf("ListPasskeys() = %+v, want %+v", passkeys, want)
+		}
+		if gotReq.GetUserId() != "user-1" {
+			t.Errorf("request UserId = %q, want %q", gotReq.GetUserId(), "user-1")
+		}
+	})
+
+	t.Run("empty result returns empty slice, not nil", func(t *testing.T) {
+		c := &SDKClient{user: &fakeUserService{
+			listPasskeys: func(context.Context, *userv2.ListPasskeysRequest, ...grpc.CallOption) (*userv2.ListPasskeysResponse, error) {
+				return &userv2.ListPasskeysResponse{}, nil
+			},
+		}}
+		passkeys, err := c.ListPasskeys(context.Background(), "user-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if passkeys == nil || len(passkeys) != 0 {
+			t.Errorf("ListPasskeys() = %#v, want empty non-nil slice", passkeys)
+		}
+	})
+
+	t.Run("propagates API errors", func(t *testing.T) {
+		boom := errors.New("boom")
+		c := &SDKClient{user: &fakeUserService{
+			listPasskeys: func(context.Context, *userv2.ListPasskeysRequest, ...grpc.CallOption) (*userv2.ListPasskeysResponse, error) {
+				return nil, boom
+			},
+		}}
+		_, err := c.ListPasskeys(context.Background(), "user-1")
 		if !errors.Is(err, boom) {
 			t.Fatalf("expected wrapped boom error, got %v", err)
 		}


### PR DESCRIPTION
## Summary

Phase A groundwork for [datum-cloud/enhancements#738](https://github.com/datum-cloud/enhancements/issues/738) (passkey support), two independent changes:

1. **`ListPasskeys` on the Zitadel SDK client** (`pkg/zitadel`): wraps user/v2 `ListPasskeys`, returning `{ID, Name, State}` per passkey. This is the read surface for the upcoming read-only `Passkey` identity kind (portal display-only card). Follows the existing `ListHumanUsers`/`ListIDPLinks` shape (logging, error wrapping, result mapping).
2. **Suspicious-login exemption for passkey sessions**: sessions whose WebAuthn factor is user-verified (i.e. a real passkey login) no longer trigger the suspicious sign-in email. A passkey login from a new device is a phishing-resistant, user-verified ceremony — not the anomaly the suspicious-login email exists for — and the planned "passkey added" notification will cover enrollment events instead. `mapZitadelSession` now carries `PasskeyVerified` from the session factors, using the same nil-safe getter chain as the neighboring fields.

## Explicitly out of scope (follow-ups)

- The `passkeys` REST resource in the aggregated apiserver — waits for the milo release containing the new `Passkey` types (no `replace` directive shipped here; the follow-up PR is ready once the release lands).
- Passkey added/removed notification email handlers — gated on verifying the Actions v2 event names against the deployed Zitadel version.

## Testing

- `go test ./pkg/zitadel/... ./internal/httpactionsserver/...`: 46 passed, 0 failed. New coverage: `TestListPasskeys` (3 subtests: mapping, empty result, error propagation), `TestMapZitadelSessionPasskeyVerified` (4 subtests), and a new exemption case in `TestSessionAddedHandler` (17/17, including the pre-existing "different IP is suspicious" case still flagging for non-passkey sessions).
- `go build ./...`, `go vet ./...`, `gofmt` all clean.

## Test plan

- [ ] CI green
- [ ] After the milo release: dependency bump + passkeys REST follow-up PR
- [ ] Staging verification that password/IdP logins still produce suspicious-login emails while passkey logins do not (once passkeys are enabled on staging)
