### PR TITLE
Make Zitadel User State Alignment Idempotent

### DIFF
--- a/internal/controller/platformaccess_controller.go
+++ b/internal/controller/platformaccess_controller.go
@@ -118,6 +118,19 @@ func (r *PlatformAccessController) stateChanged(platformAccess *iammiloapiscomv1
 }
 
 func (r *PlatformAccessController) ensureZitadelUserState(ctx context.Context, userName string, expectActive bool) error {
+	userResp, err := r.Zitadel.GetUser(ctx, userName)
+	if err != nil {
+		return fmt.Errorf("failed to get user state from Zitadel: %w", err)
+	}
+
+	currentState := userResp.User.State
+	if expectActive && currentState == zitadel.UserStateActive {
+		return nil
+	}
+	if !expectActive && currentState == zitadel.UserStateInactive {
+		return nil
+	}
+
 	if expectActive {
 		return r.Zitadel.ReactivateUser(ctx, userName)
 	}

--- a/internal/controller/platformaccess_controller_test.go
+++ b/internal/controller/platformaccess_controller_test.go
@@ -91,6 +91,12 @@ var _ = ginkgo.Describe("PlatformAccessController", func() {
 		ginkgo.It("should deactivate user in Zitadel when state is Suspended", func() {
 			var deactivateCalls int32
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/v2/users/john" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"user":{"state":"USER_STATE_ACTIVE"}}`))
+					return
+				}
 				if r.Method == http.MethodPost && r.URL.Path == "/v2/users/john/deactivate" {
 					atomic.AddInt32(&deactivateCalls, 1)
 					w.WriteHeader(http.StatusOK)
@@ -138,6 +144,12 @@ var _ = ginkgo.Describe("PlatformAccessController", func() {
 		ginkgo.It("should reactivate user in Zitadel for other states like Approved", func() {
 			var reactivateCalls int32
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/v2/users/john" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"user":{"state":"USER_STATE_INACTIVE"}}`))
+					return
+				}
 				if r.Method == http.MethodPost && r.URL.Path == "/v2/users/john/reactivate" {
 					atomic.AddInt32(&reactivateCalls, 1)
 					w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Description
This PR addresses an issue where the `platformaccess-reconciler` encounters persistent errors and reconciler retries when aligning a Zitadel user's active/inactive state. 

### Problem
When reactivating or deactivating a user, ZITADEL's API returns a `FAILED_PRECONDITION` error (HTTP 400) if the user is already in that state (e.g., trying to reactivate an already active user). This caused the reconciliation loop to fail, log errors, and retry continuously.

### Solution
- Updated the reconciliation logic in `PlatformAccessController` to fetch the user's current state via the `GetUser` Zitadel API endpoint first.
- If the user's state is already aligned with the target state, the controller successfully returns early without making unnecessary POST calls.
- Updated unit tests to mock the `GET /v2/users/{userId}` endpoint accordingly.
