### PR TITLE
docs: restructure docs/ and cover all four runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Zitadel - enabling secure identity management, token generation, and account
 lifecycle management across business entities like users, organizations, and
 machine accounts.
 
+📚 **[Documentation](docs/)** — start with [architecture.md](docs/architecture.md); the binary
+ships four independent runtimes.
+
 ## Overview
 
 This project provides the authentication foundation for the [Milo business

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# zitadel-provider Documentation
+
+zitadel-provider is the only platform component that speaks the Zitadel API. Everything else
+on the platform — Milo, the portal, auth-ui — reaches Zitadel state through this component or
+not at all.
+
+## Where to start
+
+New to this component? Read [architecture.md](architecture.md) first. It explains that the
+binary ships **four independent runtimes**, which is the single most important thing to
+understand before reading anything else here — most confusion about this repo comes from
+assuming it is one process.
+
+## Layout
+
+| Path | Contains |
+|---|---|
+| [architecture.md](architecture.md) | The four runtimes, what each does, and how they relate |
+| [components/](components/) | Feature-level docs: how a user-facing capability works end to end |
+| [runbooks/](runbooks/) | Operational and testing guides — how to exercise a thing locally |
+
+### Components
+
+| Doc | Covers |
+|---|---|
+| [passkey-authentication.md](components/passkey-authentication.md) | Passkey enrollment, login, the read-only `Passkey` kind, and the suspicious-login exemption |
+| [suspicious-login-detection.md](components/suspicious-login-detection.md) | New-device/IP/fingerprint detection on `oidc_session.added` and its notification email |
+
+### Runbooks
+
+| Doc | Covers |
+|---|---|
+| [passkey-local-testing.md](runbooks/passkey-local-testing.md) | End-to-end passkey testing against a local stack |
+| [identity-api-tests.md](runbooks/identity-api-tests.md) | Exercising the aggregated apiserver's identity kinds |
+
+## Conventions
+
+- **Component docs describe what exists.** If a capability is designed but not shipped, it
+  does not get a component doc until the code lands. Docs that describe intent rather than
+  behaviour rot silently and mislead exactly the people who trust them most.
+- **Runbooks are reproducible.** A runbook that cannot be followed start to finish on a clean
+  machine is a bug report, not documentation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,41 +1,67 @@
-# Auth Provider Zitadel Controller Architecture
+# zitadel-provider Architecture
 
 ## Overview
 
-This document explains the architecture of the Auth Provider Zitadel controller,
-which manages Zitadel authentication for users and machine accounts across the
-Milo multi-tenant platform using a dual-manager setup.
+zitadel-provider is the only platform component that speaks the Zitadel API. It ships as a
+single binary, `auth-provider-zitadel`, but that binary contains **four independent runtimes**
+selected by subcommand. They do not share process state, they are deployed separately, and
+they fail separately.
 
-## Background
+Assuming this is one process is the most common source of confusion about this repo. Read
+this section before anything else.
 
-### Milo Platform Integration
+| Runtime | Subcommand | Deployed as | Direction |
+|---|---|---|---|
+| [Controllers](#1-controllers) | `controller` | Standalone deployment, leader-elected | Milo ⇄ Zitadel |
+| [Aggregated apiserver](#2-aggregated-apiserver) | `apiserver` | Standalone deployment behind Milo | Milo → Zitadel |
+| [Actions server](#3-actions-server) | `actions-server` | **Sidecar inside the Zitadel pod** | Zitadel → Milo |
+| [Authentication webhook](#4-authentication-webhook) | `authn-webhook` | Standalone TLS webhook | Milo → Zitadel |
 
-The Milo platform provides a multi-tenant architecture where:
-- **Core Control Plane**: Platform-wide resource management and user lifecycle
-- **Project Control Planes**: Per-project resource management, dynamically
-  created
+```
+                          ┌──────────────────────────────┐
+                          │           Zitadel            │
+                          │   (source of truth for all   │
+                          │       identity state)        │
+                          │                              │
+                          │  ┌────────────────────────┐  │
+                          │  │ actions-server sidecar │  │
+                          │  │     127.0.0.1:8888     │  │
+                          │  └───────────┬────────────┘  │
+                          └──────▲───────┼───────────────┘
+                                 │       │ creates Email CRs,
+              Zitadel API calls  │       │ reads User CRs
+              (machine account)  │       │
+        ┌────────────────────────┴───┐   │
+        │                            │   │
+ ┌──────┴───────┐  ┌──────────────┐  │   │  ┌──────────────────┐
+ │ controller   │  │ apiserver    │──┘   │  │ authn-webhook    │
+ │ (leader-     │  │ (aggregated) │      │  │ (TokenReview)    │
+ │  elected)    │  │              │      │  │                  │
+ └──────┬───────┘  └──────▲───────┘      │  └────────▲─────────┘
+        │                 │              │           │
+        ▼                 │ delegated    ▼           │ authn
+ ┌──────────────────────────────────────────────────────────────┐
+ │                     Milo control planes                      │
+ │   core (platform-wide)  ·  project (per-tenant, discovered)  │
+ └──────────────────────────────────────────────────────────────┘
+```
 
-This controller integrates with Milo to synchronize authentication state with
-Zitadel.
+---
 
-### The Authentication Challenge
+## 1. Controllers
 
-This controller handles Zitadel authentication but faces a topology challenge in
-Milo's architecture:
+**Subcommand:** `controller` · **Leader-elected:** yes
 
-- **MachineAccount resources**: Live in project control planes (per-tenant,
-  discovered dynamically)
-- **UserDeactivation resources**: Live in the core control plane (platform-wide)
+Reconciles Milo resources into Zitadel state. Faces a topology problem: the resources it
+manages live in *different* Milo control planes.
 
-Both resource types need to interact with the same Zitadel instance for
-authentication management.
+- **MachineAccount** resources live in project control planes — per-tenant, discovered
+  dynamically as projects are created.
+- **UserDeactivation** resources live in the core control plane — platform-wide.
 
-## Solution: Dual Manager Architecture
+Both need the same Zitadel instance. The solution is two coordinated managers in one process.
 
-We use two coordinated managers to handle the different Milo control plane
-topologies while maintaining a single Zitadel integration point.
-
-### Architecture Diagram
+### Dual-manager architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────-┐
@@ -69,90 +95,120 @@ topologies while maintaining a single Zitadel integration point.
 │  │  └─────────────────────────────────────────────────────┘    │ │
 │  └─────────────────────────────────────────────────────────────┘ │
 └────────────────────────────────────────────────────────────────-─┘
-                              │
-                              ▼
-                    ┌─────────────────┐
-                    │     Zitadel     │
-                    │                 │
-                    │ • Machine Users │
-                    │ • Human Users   │
-                    └─────────────────┘
-
-Milo Multi-Tenant Platform:
-┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
-│ Project CP #1   │  │ Project CP #2   │  │ Core Control    │
-│ (Tenant A)      │  │ (Tenant B)      │  │ Plane           │
-│                 │  │                 │  │ (Platform-wide) │
-│ MachineAccount  │  │ MachineAccount  │  │                 │
-│ resources       │  │ resources       │  │ UserDeactivation│
-│                 │  │                 │  │ resources       │
-└─────────────────┘  └─────────────────┘  └─────────────────┘
 ```
 
-## Component Details
+### Leadership coordination
 
-### Main Multi-Tenant Manager
+The main multi-tenant manager participates in leader election and becomes the single active
+instance across all deployments. Once it achieves leadership, it signals the core control
+plane manager to start.
 
-**Purpose**: Handles MachineAccounts and other project-level resources that
-exist in Milo
+The core control plane manager is subordinate: it starts only after the main manager has
+established leadership, and stops if leadership is lost. This prevents multiple instances from
+simultaneously modifying user state in Zitadel.
 
-- Integrates with Milo's discovery system to find project control planes as
-  projects are created
-- Manages project-level Milo resources that need to be reconciled with Zitadel
-  (e.g. MachineAccounts)
-- Coordinates overall process leadership
+### Resource synchronization
 
-### Core Control Plane Manager
+**MachineAccountController** (tenant level)
 
-**Purpose**: Handles UserDeactivation authentication on Milo's core control
-plane
+- Watches `MachineAccount` resources in project control planes
+- Creates machine users in Zitadel on create; updates Active/Inactive state from spec; deletes
+  machine users on delete
+- Identity format: `{uid}@{namespace}.{project}.iam.miloapis.com`
 
-- Integrates directly with Milo's core control plane
-- Manages core Milo resources that needs to be reconciled with Zitadel (e.g.
-  UserDeactivations)
-- Operates as subordinate to main manager (starts only when main manager has
-  leadership)
+**UserDeactivationController** (platform level)
 
-### Leadership Coordination
+- Watches `UserDeactivation` resources in the core control plane
+- Deactivates users in Zitadel on create, reactivates on delete
+- Updates the corresponding `User` resource status in Milo
 
-The two managers coordinate through a leader election mechanism to ensure
-consistent authentication operations:
+### Discovery
 
-The main multi-tenant manager participates in leader election and becomes the
-single active instance across all deployments. Once it achieves leadership, it
-signals the core control plane manager to start.
+Uses Milo's native discovery to find project control planes, supports Milo's internal service
+discovery, and handles tenant onboarding/offboarding automatically.
 
-The core control plane manager operates as a subordinate - it only starts when
-the main manager has established leadership and stops if leadership is lost.
-This prevents multiple instances from simultaneously modifying user state in
-Zitadel and ensures coordinated authentication management across the entire Milo
-platform.
+---
 
-## Milo Integration Points
+## 2. Aggregated apiserver
 
-### Resource Synchronization
+**Subcommand:** `apiserver` · **Leader-elected:** no
 
-#### MachineAccountController (Tenant Level)
+A Kubernetes aggregated apiserver backing read-only `identity.miloapis.com` kinds. Milo serves
+the kinds and owns schema, OpenAPI, and authorization; it delegates the actual data fetch here
+via per-kind provider URLs (for example `--passkeys-provider-url`). **Milo holds no Zitadel
+knowledge.**
 
-- **Milo Integration**: Watches `MachineAccount` resources in project control
-  planes
-- **Zitadel Operations**:
-  - Creates machine users in Zitadel when MachineAccount is created in Milo
-  - Updates machine user state (Active/Inactive) based on MachineAccount spec
-  - Deletes machine users when MachineAccount is deleted from Milo
-- **Identity Format**: `{uid}@{namespace}.{project}.iam.miloapis.com`
+Kinds backed by this runtime (`internal/apiserver/`):
 
-#### UserDeactivationController (Platform Level)
+| Kind | Backed by |
+|---|---|
+| `Passkey` | Zitadel user/v2 `ListPasskeys` |
+| `Session` | Zitadel session listing |
+| `UserIdentity` | Zitadel IdP link listing |
+| `ServiceAccountKey` | Zitadel machine key listing |
 
-- **Milo Integration**: Watches `UserDeactivation` resources in core control
-  plane
-- **Zitadel Operations**:
-  - Deactivates users in Zitadel when UserDeactivation is created in Milo
-  - Reactivates users in Zitadel when UserDeactivation is deleted from Milo
-  - Updates corresponding `User` resource status in Milo
+Authorization follows one pattern across all of them: self-scoped lists resolve through the
+`X-Remote-Uid` header, and cross-user reads require a SubjectAccessReview against the owner
+field selector.
 
-### Discovery Integration
+**This path is read-only by construction.** No create, update, or delete verbs are served, so
+a compromised read path cannot mutate identity state.
 
-- Uses Milo's native discovery to find project control planes
-- Supports Milo's internal service discovery for efficient communication
-- Automatically handles tenant lifecycle (onboarding/offboarding)
+---
+
+## 3. Actions server
+
+**Subcommand:** `actions-server` · **Deployed as a sidecar container inside the Zitadel pod**
+
+Receives Zitadel Actions v2 webhooks and translates them into Milo resources. This is the only
+runtime Zitadel calls outbound into.
+
+It listens on `127.0.0.1:8888` and is reachable only from inside the Zitadel pod — which is
+why every configured Actions target endpoint is `https://localhost:8888/v1/actions/...` rather
+than a cluster service address.
+
+Registered routes (`internal/httpactionsserver/server.go`):
+
+| Route | Purpose |
+|---|---|
+| `/v1/actions/create-user-account` | User self-registration → Milo `User` CR |
+| `/v1/actions/customize-jwt` | Token claim customization |
+| `/v1/actions/idp-intent-succeeded` | External IdP link completion |
+| `/v1/actions/session-added` | Suspicious-login detection ([doc](components/suspicious-login-detection.md)) |
+| `/v1/actions/passkey-added` | Passkey enrollment notification ([doc](components/passkey-authentication.md)) |
+
+Every handler validates an HMAC over the raw request body against the `Zitadel-Signature`
+header before parsing anything. Notification handlers are deliberately fire-and-forget:
+failures are logged rather than returned as HTTP errors, because Zitadel only needs the `200`
+ack that its webhook was received.
+
+**Subject vs creator — read this before adding a handler.** The event envelope's top-level
+`userID` is the event *creator*, which is not always the user the event is *about*. Calls made
+server-side on a user's behalf resolve `userID` to the calling service account and
+`aggregateID` to the actual human. Handlers must pick the correct field for their event shape;
+`passkey_added.go` records a live-fire case where getting this wrong silently produced zero
+notifications for every real enrollment.
+
+---
+
+## 4. Authentication webhook
+
+**Subcommand:** `authn-webhook` · **Default port:** 9443 (TLS)
+
+A Kubernetes `TokenReview` webhook. Milo's apiserver calls it to authenticate bearer tokens; it
+validates them against Zitadel via token introspection and returns the resolved user identity.
+
+It also enforces deactivation at authentication time: a user with an active `UserDeactivation`
+fails token review, so deactivation takes effect on the next request instead of waiting for a
+token to expire.
+
+Zitadel API access uses a service-account JWT with a configurable lifetime
+(`--jwt-expiration`) and proactive refresh (`--jwt-refresh-before`), so introspection does not
+stall on an expired credential.
+
+---
+
+## Component documentation
+
+Runtime-level detail lives here. For how a user-facing capability works end to end across
+several runtimes, see [components/](components/).

--- a/docs/components/passkey-authentication.md
+++ b/docs/components/passkey-authentication.md
@@ -67,7 +67,9 @@ Sessions whose WebAuthn factor is **user-verified** (a real passkey login) do no
 This component requires:
 
 - **Login policy** — `passwordlessType: PASSWORDLESS_TYPE_ALLOWED` on the instance/org, per environment.
-- **Actions v2** (for lifecycle notifications) — a `REST Webhook` target on the actions sidecar (`https://localhost:8888/v1/actions/...`) with event conditions for passkey add/remove, following the existing suspicious-login wiring.
+- **Actions v2** (for lifecycle notifications) — a `REST Webhook` target on the actions sidecar (`https://localhost:8888/v1/actions/...`), following the existing suspicious-login wiring. The enrollment notification binds to **`user.human.passwordless.token.verified`** — the ceremony *completion* event, whose payload carries the user-assigned `webAuthNTokenName`.
+
+  Do **not** bind it to `user.human.passwordless.token.added`. That event fires when a ceremony *starts*, so abandoned enrollments emit it too, and its payload carries no name. Both strings are bindable and were confirmed live against v4.12.2, as is `user.human.passwordless.token.removed`. Zitadel validates condition strings — a plausible-looking wrong guess is rejected with a 404 rather than silently accepted — so typos surface at configuration time. The `.added` vs `.verified` distinction does not, because both are valid. See the doc comments in `internal/httpactionsserver/passkey_added.go` for the evidence.
 - WebAuthn credentials bind to the RP ID of the login domain. Changing that domain invalidates every enrolled passkey — treat it as a one-way door.
 
 ## Dependencies

--- a/docs/runbooks/identity-api-tests.md
+++ b/docs/runbooks/identity-api-tests.md
@@ -273,6 +273,6 @@ These tests can be integrated into CI/CD pipelines:
 
 ## Related Documentation
 
-- [Architecture Overview](./architecture.md)
+- [Architecture Overview](../architecture.md)
 - [Milo Identity API Documentation](https://github.com/milo-os/milo/blob/main/docs/api/identity.md)
 - [Zitadel Integration](https://zitadel.com/docs)

--- a/docs/runbooks/passkey-local-testing.md
+++ b/docs/runbooks/passkey-local-testing.md
@@ -6,7 +6,7 @@ with it, and confirm the "passkey added" notification. This proves the whole
 chain — `auth-ui → Zitadel → zitadel-provider → Milo → cloud-portal` — on one
 machine, without staging.
 
-See also: [components/passkey-authentication.md](components/passkey-authentication.md)
+See also: [components/passkey-authentication.md](../components/passkey-authentication.md)
 for the architecture.
 
 ## Prerequisites


### PR DESCRIPTION
Prep for Phase B — pushed ahead of the phase so the team can review the structure before feature docs land on top of it.

## Why

- `docs/` had no index — landing on `/tree/main/docs` gave five files and no entry point
- `architecture.md` was titled "Controller Architecture" and covered only one of the four runtimes; its title concealed the gap
- Runbooks sat loose in the root while feature docs had a subfolder

## What changed

```
docs/
├── README.md          NEW       index + reading order
├── architecture.md    RESCOPED  all four runtimes
├── components/        unchanged
└── runbooks/          MOVED     the two testing guides (git mv)
```

`auth-provider-zitadel` is one binary containing four independent runtimes selected by subcommand — controller, aggregated apiserver, actions server (a sidecar inside the Zitadel pod), and authn-webhook. Only the first was documented. The existing dual-manager material is preserved as the controllers section.

## One correction worth a look

`components/passkey-authentication.md` said the Actions target needs "event conditions for passkey add/remove". The handler deliberately binds `user.human.passwordless.token.verified` — ceremony completion, payload carries `webAuthNTokenName` — and **not** `user.human.passwordless.token.added`, which fires when a ceremony starts (abandoned enrollments emit it) and carries no name.

Both are valid condition strings, so Zitadel's 404-on-malformed-condition catches typos but cannot catch binding the wrong-but-real event. The doc now says which and why.

## Not in this PR

`email-delivery.md`, the signup ceremony ordering change, and narrowing the read-only invariant once `User.status.emailVerified` writes exist. Those describe Phase B behaviour that doesn't exist yet — each rides its own implementation PR.

Docs only, no behaviour changes. All relative links across `docs/` and the root README verified to resolve.